### PR TITLE
Re-org swap flow

### DIFF
--- a/contracts/interfaces/IProAMMFactory.sol
+++ b/contracts/interfaces/IProAMMFactory.sol
@@ -13,8 +13,8 @@ interface IProAMMFactory {
   /// @param tickSpacing Minimum number of ticks between initialized ticks
   /// @param pool The address of the created pool
   event PoolCreated(
-    IERC20 indexed token0,
-    IERC20 indexed token1,
+    address indexed token0,
+    address indexed token1,
     uint16 indexed swapFeeBps,
     int24 tickSpacing,
     address pool
@@ -62,8 +62,8 @@ interface IProAMMFactory {
   /// @param swapFeeBps Fee to be collected upon every swap in the pool, in basis points
   /// @return pool The pool address. Returns null address if it does not exist
   function getPool(
-    IERC20 tokenA,
-    IERC20 tokenB,
+    address tokenA,
+    address tokenB,
     uint16 swapFeeBps
   ) external view returns (address pool);
 
@@ -78,8 +78,8 @@ interface IProAMMFactory {
   ///     3) invalid token arguments
   /// @return pool The address of the newly created pool
   function createPool(
-    IERC20 tokenA,
-    IERC20 tokenB,
+    address tokenA,
+    address tokenB,
     uint16 swapFeeBps
   ) external returns (address pool);
 

--- a/contracts/interfaces/IProAMMPool.sol
+++ b/contracts/interfaces/IProAMMPool.sol
@@ -75,7 +75,7 @@ interface IProAMMPool is IProAMMPoolActions, IProAMMPoolEvents {
 
   /// @notice Look up information about a specific tick in the pool
   /// @param tick The tick to look up
-  /// @return liquidityGross the total amount of position liquidity 
+  /// @return liquidityGross the total amount of position liquidity
   /// that uses the pool either as tick lower or tick upper
   /// liquidityNet how much liquidity changes when the pool tick crosses above the tick
   /// feeGrowthOutside the fee growth on the other side of the tick from the current tick

--- a/contracts/interfaces/pool/IProAMMPoolActions.sol
+++ b/contracts/interfaces/pool/IProAMMPoolActions.sol
@@ -25,10 +25,7 @@ interface IProAMMPoolActions {
   /// implement the mint callback as well
   /// @param poolSqrtPrice the initial sqrt price of the pool
   /// @param data Data (if any) to be passed through to the callback
-  function unlockPool(
-    uint160 poolSqrtPrice,
-    bytes calldata data
-  ) external;
+  function unlockPool(uint160 poolSqrtPrice, bytes calldata data) external;
 
   /// @notice Adds liquidity for the specifient recipient/tickLower/tickUpper position
   /// @dev Any token0 or token1 owed for the liquidity provision have to be paid for when

--- a/contracts/libraries/QtyDeltaMath.sol
+++ b/contracts/libraries/QtyDeltaMath.sol
@@ -18,8 +18,18 @@ library QtyDeltaMath {
     pure
     returns (uint256 qty0, uint256 qty1)
   {
-    qty0 = getQty0Delta(TickMath.MIN_SQRT_RATIO, initialSqrtPrice, MathConstants.MIN_LIQUIDITY, false);
-    qty1 = getQty1Delta(initialSqrtPrice, TickMath.MAX_SQRT_RATIO, MathConstants.MIN_LIQUIDITY, false);
+    qty0 = getQty0Delta(
+      TickMath.MIN_SQRT_RATIO,
+      initialSqrtPrice,
+      MathConstants.MIN_LIQUIDITY,
+      false
+    );
+    qty1 = getQty1Delta(
+      initialSqrtPrice,
+      TickMath.MAX_SQRT_RATIO,
+      MathConstants.MIN_LIQUIDITY,
+      false
+    );
   }
 
   /// @notice Gets the qty0 delta between two prices

--- a/contracts/libraries/SwapMath.sol
+++ b/contracts/libraries/SwapMath.sol
@@ -155,11 +155,13 @@ library SwapMath {
     if (isToken0) {
       numerator = FullMath.mulDivFloor(lpPluslf + lc, sqrtPc, MathConstants.TWO_POW_96);
       uint256 denominator = FullMath.mulDivCeiling(absDelta, sqrtPc, MathConstants.TWO_POW_96);
-      sqrtPn = (FullMath.mulDivFloor(
-        numerator,
-        MathConstants.TWO_POW_96,
-        isExactInput ? lpPluslf + denominator : lpPluslf - denominator
-      ))
+      sqrtPn = (
+        FullMath.mulDivFloor(
+          numerator,
+          MathConstants.TWO_POW_96,
+          isExactInput ? lpPluslf + denominator : lpPluslf - denominator
+        )
+      )
       .toUint160();
     } else {
       numerator = FullMath.mulDivFloor(lpPluslf, sqrtPc, MathConstants.TWO_POW_96);

--- a/contracts/libraries/SwapMath.sol
+++ b/contracts/libraries/SwapMath.sol
@@ -10,6 +10,49 @@ library SwapMath {
   using SafeCast for uint256;
   using SafeCast for int256;
 
+  function computeSwapStep(
+    uint256 liquidity,
+    uint160 currentSqrtP,
+    uint160 targetSqrtP,
+    uint16 feeInBps,
+    int256 amountRemaining,
+    bool isExactInput
+  )
+    internal
+    pure
+    returns (
+      int256 delta,
+      int256 actualDelta,
+      uint256 fee,
+      uint160 nextSqrtP
+    )
+  {
+    // if isExactInput, isToken0 == !willUpTick else isToken0 = willUpTick;
+    bool isToken0 = isExactInput ? (currentSqrtP > targetSqrtP) : (currentSqrtP < targetSqrtP);
+
+    delta = calcDeltaNext(liquidity, currentSqrtP, targetSqrtP, feeInBps, isExactInput, isToken0);
+
+    if (isExactInput) {
+      if (delta >= amountRemaining) {
+        delta = amountRemaining;
+      } else {
+        nextSqrtP = targetSqrtP;
+      }
+    } else {
+      if (delta <= amountRemaining) {
+        delta = amountRemaining;
+      } else {
+        nextSqrtP = targetSqrtP;
+      }
+    }
+    uint256 absDelta = delta >= 0 ? uint256(delta) : delta.revToUint256();
+    fee = calcSwapFeeAmounts(absDelta, currentSqrtP, feeInBps, isExactInput, isToken0);
+    if (nextSqrtP == 0) {
+      nextSqrtP = calcFinalPrice(absDelta, liquidity, fee, currentSqrtP, isExactInput, isToken0);
+    }
+    actualDelta = calcActualDelta(liquidity, currentSqrtP, nextSqrtP, fee, isExactInput, isToken0);
+  }
+
   // calculates the delta qty amount needed to reach sqrtPn (price of next tick)
   // from sqrtPc (price of current tick)
   function calcDeltaNext(
@@ -51,71 +94,6 @@ library SwapMath {
       deltaNext = FullMath.mulDivFloor(numerator, sqrtPc, denominator).toInt256();
     }
     if (!isExactInput) deltaNext = -deltaNext;
-  }
-
-  struct SwapParams {
-    // if won't cross tick, deltaRemaining;
-    // else, deltaNext (delta qty needed to cross next tick)
-    int256 deltaRemaining;
-    int256 actualDelta;
-    uint256 lpPluslf;
-    uint256 lc;
-    uint160 sqrtPc;
-    uint160 sqrtPn;
-    uint16 swapFeeBps;
-    bool isExactInput;
-    bool isToken0;
-    // true if needed to calculate final sqrt price, false otherwise
-    bool calcFinalPrice;
-  }
-
-  // calculates actual delta and fee amounts (lc and governmentFee)
-  // in addition, will return non-zero sqrtPn if calcFinalPrice is true
-  function calcSwapInTick(SwapParams memory swapParams)
-    internal
-    pure
-    returns (
-      int256 actualDelta,
-      uint256 lc,
-      uint160 sqrtPn
-    )
-  {
-    uint256 absDelta = swapParams.deltaRemaining >= 0
-      ? uint256(swapParams.deltaRemaining)
-      : swapParams.deltaRemaining.revToUint256();
-    // calculate fee amounts
-    swapParams.lc = calcSwapFeeAmounts(
-      absDelta,
-      swapParams.sqrtPc,
-      swapParams.swapFeeBps,
-      swapParams.isExactInput,
-      swapParams.isToken0
-    );
-
-    if (swapParams.calcFinalPrice) {
-      // calculate final sqrt price
-      swapParams.sqrtPn = calcFinalPrice(
-        absDelta,
-        swapParams.lpPluslf,
-        swapParams.lc,
-        swapParams.sqrtPc,
-        swapParams.isExactInput,
-        swapParams.isToken0
-      );
-    }
-    // calculate actualDelta
-    actualDelta =
-      swapParams.actualDelta +
-      calcActualDelta(
-        swapParams.lpPluslf,
-        swapParams.sqrtPc,
-        swapParams.sqrtPn,
-        swapParams.lc,
-        swapParams.isExactInput,
-        swapParams.isToken0
-      );
-
-    return (actualDelta, swapParams.lc, swapParams.sqrtPn);
   }
 
   function calcSwapFeeAmounts(

--- a/contracts/mock/PredictPoolAddress.sol
+++ b/contracts/mock/PredictPoolAddress.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.6;
+pragma solidity 0.8.4;
 
 import {IERC20} from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 import {Clones} from '@openzeppelin/contracts/proxy/Clones.sol';

--- a/contracts/mock/callback/MockProAMMCallbacks.sol
+++ b/contracts/mock/callback/MockProAMMCallbacks.sol
@@ -56,10 +56,7 @@ contract MockProAMMCallbacks is IProAMMMintCallback, IProAMMSwapCallback {
     bool sendLess0,
     bool sendLess1
   ) external {
-    pool.unlockPool(
-      poolSqrtPrice,
-      abi.encode(sendLess0, sendLess1)
-    );
+    pool.unlockPool(poolSqrtPrice, abi.encode(sendLess0, sendLess1));
   }
 
   function badMint(

--- a/contracts/reinvestmentToken/ERC20PermitInitializable.sol
+++ b/contracts/reinvestmentToken/ERC20PermitInitializable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.6;
+pragma solidity 0.8.4;
 
 import {ERC20Initializable} from './ERC20Initializable.sol';
 import '../interfaces/IERC20Permit.sol';

--- a/contracts/reinvestmentToken/ReinvestmentTokenMaster.sol
+++ b/contracts/reinvestmentToken/ReinvestmentTokenMaster.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: agpl-3.0
-pragma solidity 0.8.6;
+pragma solidity 0.8.4;
 
 import {ERC20PermitInitializable} from './ERC20PermitInitializable.sol';
 import {IReinvestmentToken} from '../interfaces/IReinvestmentToken.sol';

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -29,7 +29,7 @@ const config: HardhatUserConfig = {
   solidity: {
     compilers: [
       {
-        version: '0.8.6',
+        version: '0.8.4',
         settings: {
           optimizer: {
             enabled: true,

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "decimal.js": "^10.3.1",
     "ethereum-waffle": "3.3.0",
     "ethers": "5.0.0",
-    "hardhat": "2.4.3",
+    "hardhat": "2.6.0",
     "hardhat-contract-sizer": "^2.0.3",
     "hardhat-gas-reporter": "1.0.4",
     "hardhat-typechain": "0.3.5",

--- a/test/ProAMMFactory.spec.ts
+++ b/test/ProAMMFactory.spec.ts
@@ -38,7 +38,7 @@ describe('ProAMMFactory', () => {
     Token = (await ethers.getContractFactory('MockToken')) as MockToken__factory;
     tokenA = await Token.deploy('USDC', 'USDC', BN.from(1000).mul(PRECISION));
     tokenB = await Token.deploy('DAI', 'DAI', BN.from(1000).mul(PRECISION));
-    return (await deployFactory(ethers, admin, reinvestmentMaster.address, poolMaster.address));
+    return await deployFactory(ethers, admin, reinvestmentMaster.address, poolMaster.address);
   }
 
   describe('#factory deployment and pool creation', async () => {
@@ -67,7 +67,8 @@ describe('ProAMMFactory', () => {
         tokenB.address,
         swapFeeBps
       );
-      let token0Address = tokenA.address.toLowerCase() < tokenB.address.toLowerCase() ? tokenA.address : tokenB.address;
+      let token0Address =
+        tokenA.address.toLowerCase() < tokenB.address.toLowerCase() ? tokenA.address : tokenB.address;
       let token1Address = token0Address == tokenA.address ? tokenB.address : tokenA.address;
       await expect(factory.createPool(tokenA.address, tokenB.address, swapFeeBps))
         .to.emit(factory, 'PoolCreated')

--- a/test/ProAMMPool.spec.ts
+++ b/test/ProAMMPool.spec.ts
@@ -813,8 +813,8 @@ describe('ProAMMPool', () => {
         // push current tick to below tickLower
         await swapToDownTick(pool, user, tickLower);
         await expect(pool.connect(user).burn(tickLower, tickUpper, PRECISION))
-        .to.emit(token0, 'Transfer')
-        .to.not.emit(token1, 'Transfer');
+          .to.emit(token0, 'Transfer')
+          .to.not.emit(token1, 'Transfer');
       });
 
       it('should transfer token0 and token1 if current tick is within position burnt', async () => {
@@ -823,8 +823,8 @@ describe('ProAMMPool', () => {
         // push current tick to slightly above tickLower
         await swapToDownTick(pool, user, tickLower + 10);
         await expect(pool.connect(user).burn(tickLower, tickUpper, PRECISION))
-        .to.emit(token1, 'Transfer')
-        .to.emit(token0, 'Transfer');
+          .to.emit(token1, 'Transfer')
+          .to.emit(token0, 'Transfer');
       });
 
       it('should only transfer token1 if position burnt is below current tick', async () => {
@@ -832,8 +832,8 @@ describe('ProAMMPool', () => {
         await swapToUpTick(pool, user, tickUpper);
         // await pool.connect(user).burn(tickLower, tickUpper, PRECISION);
         await expect(pool.connect(user).burn(tickLower, tickUpper, PRECISION))
-        .to.emit(token1, 'Transfer')
-        .to.not.emit(token0, 'Transfer');
+          .to.emit(token1, 'Transfer')
+          .to.not.emit(token0, 'Transfer');
       });
     });
   });
@@ -958,7 +958,14 @@ describe('ProAMMPool', () => {
       console.log(`tick: ${(await pool.getPoolState())._poolTick.toString()}`);
       console.log(`price: ${(await pool.getPoolState())._poolSqrtPrice.toString()}`);
       console.log(`reinvestment: ${(await pool.getReinvestmentState())._poolReinvestmentLiquidity.toString()}`);
-      await callback.swap(pool.address, user.address, BN.from('-1751372543351715671'), false, MIN_SQRT_RATIO.add(ONE), '0x');
+      await callback.swap(
+        pool.address,
+        user.address,
+        BN.from('-1751372543351715671'),
+        false,
+        MIN_SQRT_RATIO.add(ONE),
+        '0x'
+      );
       let token0BalanceAfter = await token0.balanceOf(user.address);
       let token1BalanceAfter = await token1.balanceOf(user.address);
       console.log(`=== AFTER SWAP ===`);

--- a/test/helpers/utils.ts
+++ b/test/helpers/utils.ts
@@ -8,8 +8,8 @@ bn.config({EXPONENTIAL_AT: 999999, DECIMAL_PLACES: 40});
 
 export {BigNumber} from 'ethers';
 
-export const getMinTick = (tickSpacing: number) => Math.ceil(MIN_TICK.toNumber() / tickSpacing) * tickSpacing
-export const getMaxTick = (tickSpacing: number) => Math.floor(MAX_TICK.toNumber() / tickSpacing) * tickSpacing
+export const getMinTick = (tickSpacing: number) => Math.ceil(MIN_TICK.toNumber() / tickSpacing) * tickSpacing;
+export const getMaxTick = (tickSpacing: number) => Math.floor(MAX_TICK.toNumber() / tickSpacing) * tickSpacing;
 
 export function encodePriceSqrt(reserve1: BigNumberish, reserve0: BigNumberish): BigNumber {
   return BigNumber.from(
@@ -23,7 +23,7 @@ export function encodePriceSqrt(reserve1: BigNumberish, reserve0: BigNumberish):
 }
 
 export async function getNearestSpacedTickAtPrice(sqrtRatio: BigNumber, tickSpacing: number): Promise<BigNumber> {
-  return BigNumber.from(Math.ceil((await _getTickAtPrice(sqrtRatio)) / tickSpacing) * tickSpacing)
+  return BigNumber.from(Math.ceil((await _getTickAtPrice(sqrtRatio)) / tickSpacing) * tickSpacing);
 }
 
 export async function getTickAtPrice(sqrtRatio: BigNumber): Promise<BigNumberish> {

--- a/test/libraries/SwapMath.spec.ts
+++ b/test/libraries/SwapMath.spec.ts
@@ -46,13 +46,7 @@ describe('SwapMath', () => {
     const delta = await swapMath.calcDeltaNext(liquidity, priceStart, priceEnd, fee, false, false);
     console.log(`delta: ${delta.toString()}`); // -0.004970250488226176
 
-    const lc = await swapMath.calcSwapFeeAmounts(
-      delta.mul(NEGATIVE_ONE).sub(ONE),
-      priceStart,
-      fee,
-      false,
-      false
-    );
+    const lc = await swapMath.calcSwapFeeAmounts(delta.mul(NEGATIVE_ONE).sub(ONE), priceStart, fee, false, false);
     console.log(`lc=${lc.toString()}`); // 0.000007477809159818 = 0.004970250488226176 * 0.003 / (2 * 0.997)
 
     const finalPrice = await swapMath.calcFinalPrice(

--- a/yarn.lock
+++ b/yarn.lock
@@ -143,10 +143,10 @@
     "@ethereumjs/common" "^2.4.0"
     ethereumjs-util "^7.1.0"
 
-"@ethereumjs/vm@^5.5.0":
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/@ethereumjs/vm/-/vm-5.5.0.tgz#d389c5792320ef28c51366a643b8ab9d64e10a31"
-  integrity sha512-h6Kr6WqKUP8nVuEzCWPWEPrC63v7HFwt3gRuK7CJiyg9S0iWSBKUA/YVD4YgaSVACuxUfWaOBbwV5uGVupm5PQ==
+"@ethereumjs/vm@^5.5.2":
+  version "5.5.2"
+  resolved "https://registry.yarnpkg.com/@ethereumjs/vm/-/vm-5.5.2.tgz#918a2c1000aaa9fdbe6007a4fdc2c62833122adf"
+  integrity sha512-AydZ4wfvZAsBuFzs3xVSA2iU0hxhL8anXco3UW3oh9maVC34kTEytOfjHf06LTEfN0MF9LDQ4ciLa7If6ZN/sg==
   dependencies:
     "@ethereumjs/block" "^3.4.0"
     "@ethereumjs/blockchain" "^5.4.0"
@@ -4861,16 +4861,16 @@ hardhat-typechain@0.3.5:
   resolved "https://registry.yarnpkg.com/hardhat-typechain/-/hardhat-typechain-0.3.5.tgz#8e50616a9da348b33bd001168c8fda9c66b7b4af"
   integrity sha512-w9lm8sxqTJACY+V7vijiH+NkPExnmtiQEjsV9JKD1KgMdVk2q8y+RhvU/c4B7+7b1+HylRUCxpOIvFuB3rE4+w==
 
-hardhat@2.4.3:
-  version "2.4.3"
-  resolved "https://registry.yarnpkg.com/hardhat/-/hardhat-2.4.3.tgz#093373b383eacec0d3e7fb223353b2f0cb9f2802"
-  integrity sha512-xgbnhEnmaKau8xT6wPJlzoyMLAZyxQoElACQQCyEeAY1DURpZbYwjIQUywmL/ZNv3QEl38Yqu/n8mPOc2HXyGA==
+hardhat@2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/hardhat/-/hardhat-2.6.0.tgz#a00a44d36559a880c170dca6363cc33f7545364b"
+  integrity sha512-NEM2pe11QXWXB7k49heOLQA9vxihG4DJ0712KjMT9NYSZgLOMcWswJ3tvn+/ND6vzLn6Z4pqr2x/kWSfllWFuw==
   dependencies:
     "@ethereumjs/block" "^3.4.0"
     "@ethereumjs/blockchain" "^5.4.0"
     "@ethereumjs/common" "^2.4.0"
     "@ethereumjs/tx" "^3.3.0"
-    "@ethereumjs/vm" "^5.5.0"
+    "@ethereumjs/vm" "^5.5.2"
     "@ethersproject/abi" "^5.1.2"
     "@sentry/node" "^5.18.1"
     "@solidity-parser/parser" "^0.11.0"


### PR DESCRIPTION
Fix bugs:
- Condition to cross a tick change to if next price == price of next Tick. 
For example: if current price = 1000, price of next Tick = 4000, amountIn is very big, priceLimit =2000
the condition at [here](https://github.com/KyberNetwork/pro-amm/blob/addTests/contracts/ProAMMPool.sol#L545) is wrong
  - swapData.sqrtPn will be 2000
  - hence the swapData.deltaNext do not reach swapData.deltaRemaining, but it does not cross a tick 
- The feeGrowth when crossing a tick only depends on lf and lfLast (according the the docs)
    - At [here](https://github.com/KyberNetwork/pro-amm/blob/addTests/contracts/ProAMMPool.sol#L611),  there is a case: 
 At 1st swap swapData.lc = 10 and not cross a tick
At the 2nd swap swapData.lc = 20 and cross a tick
The rMint should be accounted for both swap.  (calculated by lf = lfLast + 30 and lf)


Also re-org to make it easier to review