### PR TITLE
Gas optimize

### DIFF
--- a/contracts/interfaces/IProAMMPool.sol
+++ b/contracts/interfaces/IProAMMPool.sol
@@ -66,8 +66,8 @@ interface IProAMMPool is IProAMMPoolActions, IProAMMPoolEvents {
     view
     returns (
       uint256 poolFeeGrowthGlobal,
-      uint256 poolReinvestmentLiquidity,
-      uint256 poolReinvestmentLiquidityLast
+      uint128 poolReinvestmentLiquidity,
+      uint128 poolReinvestmentLiquidityLast
     );
 
   /// @notice Look up information about a specific tick in the pool

--- a/contracts/libraries/TickMath.sol
+++ b/contracts/libraries/TickMath.sol
@@ -21,42 +21,44 @@ library TickMath {
   /// @return sqrtPriceX96 A Fixed point Q64.96 number representing the sqrt of the ratio of the two assets (token1/token0)
   /// at the given tick
   function getSqrtRatioAtTick(int24 tick) internal pure returns (uint160 sqrtPriceX96) {
-    uint256 absTick = tick < 0 ? uint256(-int256(tick)) : uint256(int256(tick));
-    require(absTick <= uint256(int256(MAX_TICK)), 'T');
+    unchecked {
+      uint256 absTick = uint256(tick < 0 ? -int256(tick) : int256(tick));
+      require(absTick <= uint256(int256(MAX_TICK)), 'T');
 
-    // do bitwise comparison, if i-th bit is turned on,
-    // multiply ratio by hardcoded values of sqrt(1.0001^-(2^i)) * 2^128
-    // where 0 <= i <= 19
-    uint256 ratio = absTick & 0x1 != 0
-      ? 0xfffcb933bd6fad37aa2d162d1a594001
-      : 0x100000000000000000000000000000000;
-    if (absTick & 0x2 != 0) ratio = (ratio * 0xfff97272373d413259a46990580e213a) >> 128;
-    if (absTick & 0x4 != 0) ratio = (ratio * 0xfff2e50f5f656932ef12357cf3c7fdcc) >> 128;
-    if (absTick & 0x8 != 0) ratio = (ratio * 0xffe5caca7e10e4e61c3624eaa0941cd0) >> 128;
-    if (absTick & 0x10 != 0) ratio = (ratio * 0xffcb9843d60f6159c9db58835c926644) >> 128;
-    if (absTick & 0x20 != 0) ratio = (ratio * 0xff973b41fa98c081472e6896dfb254c0) >> 128;
-    if (absTick & 0x40 != 0) ratio = (ratio * 0xff2ea16466c96a3843ec78b326b52861) >> 128;
-    if (absTick & 0x80 != 0) ratio = (ratio * 0xfe5dee046a99a2a811c461f1969c3053) >> 128;
-    if (absTick & 0x100 != 0) ratio = (ratio * 0xfcbe86c7900a88aedcffc83b479aa3a4) >> 128;
-    if (absTick & 0x200 != 0) ratio = (ratio * 0xf987a7253ac413176f2b074cf7815e54) >> 128;
-    if (absTick & 0x400 != 0) ratio = (ratio * 0xf3392b0822b70005940c7a398e4b70f3) >> 128;
-    if (absTick & 0x800 != 0) ratio = (ratio * 0xe7159475a2c29b7443b29c7fa6e889d9) >> 128;
-    if (absTick & 0x1000 != 0) ratio = (ratio * 0xd097f3bdfd2022b8845ad8f792aa5825) >> 128;
-    if (absTick & 0x2000 != 0) ratio = (ratio * 0xa9f746462d870fdf8a65dc1f90e061e5) >> 128;
-    if (absTick & 0x4000 != 0) ratio = (ratio * 0x70d869a156d2a1b890bb3df62baf32f7) >> 128;
-    if (absTick & 0x8000 != 0) ratio = (ratio * 0x31be135f97d08fd981231505542fcfa6) >> 128;
-    if (absTick & 0x10000 != 0) ratio = (ratio * 0x9aa508b5b7a84e1c677de54f3e99bc9) >> 128;
-    if (absTick & 0x20000 != 0) ratio = (ratio * 0x5d6af8dedb81196699c329225ee604) >> 128;
-    if (absTick & 0x40000 != 0) ratio = (ratio * 0x2216e584f5fa1ea926041bedfe98) >> 128;
-    if (absTick & 0x80000 != 0) ratio = (ratio * 0x48a170391f7dc42444e8fa2) >> 128;
+      // do bitwise comparison, if i-th bit is turned on,
+      // multiply ratio by hardcoded values of sqrt(1.0001^-(2^i)) * 2^128
+      // where 0 <= i <= 19
+      uint256 ratio = (absTick & 0x1 != 0)
+        ? 0xfffcb933bd6fad37aa2d162d1a594001
+        : 0x100000000000000000000000000000000;
+      if (absTick & 0x2 != 0) ratio = (ratio * 0xfff97272373d413259a46990580e213a) >> 128;
+      if (absTick & 0x4 != 0) ratio = (ratio * 0xfff2e50f5f656932ef12357cf3c7fdcc) >> 128;
+      if (absTick & 0x8 != 0) ratio = (ratio * 0xffe5caca7e10e4e61c3624eaa0941cd0) >> 128;
+      if (absTick & 0x10 != 0) ratio = (ratio * 0xffcb9843d60f6159c9db58835c926644) >> 128;
+      if (absTick & 0x20 != 0) ratio = (ratio * 0xff973b41fa98c081472e6896dfb254c0) >> 128;
+      if (absTick & 0x40 != 0) ratio = (ratio * 0xff2ea16466c96a3843ec78b326b52861) >> 128;
+      if (absTick & 0x80 != 0) ratio = (ratio * 0xfe5dee046a99a2a811c461f1969c3053) >> 128;
+      if (absTick & 0x100 != 0) ratio = (ratio * 0xfcbe86c7900a88aedcffc83b479aa3a4) >> 128;
+      if (absTick & 0x200 != 0) ratio = (ratio * 0xf987a7253ac413176f2b074cf7815e54) >> 128;
+      if (absTick & 0x400 != 0) ratio = (ratio * 0xf3392b0822b70005940c7a398e4b70f3) >> 128;
+      if (absTick & 0x800 != 0) ratio = (ratio * 0xe7159475a2c29b7443b29c7fa6e889d9) >> 128;
+      if (absTick & 0x1000 != 0) ratio = (ratio * 0xd097f3bdfd2022b8845ad8f792aa5825) >> 128;
+      if (absTick & 0x2000 != 0) ratio = (ratio * 0xa9f746462d870fdf8a65dc1f90e061e5) >> 128;
+      if (absTick & 0x4000 != 0) ratio = (ratio * 0x70d869a156d2a1b890bb3df62baf32f7) >> 128;
+      if (absTick & 0x8000 != 0) ratio = (ratio * 0x31be135f97d08fd981231505542fcfa6) >> 128;
+      if (absTick & 0x10000 != 0) ratio = (ratio * 0x9aa508b5b7a84e1c677de54f3e99bc9) >> 128;
+      if (absTick & 0x20000 != 0) ratio = (ratio * 0x5d6af8dedb81196699c329225ee604) >> 128;
+      if (absTick & 0x40000 != 0) ratio = (ratio * 0x2216e584f5fa1ea926041bedfe98) >> 128;
+      if (absTick & 0x80000 != 0) ratio = (ratio * 0x48a170391f7dc42444e8fa2) >> 128;
 
-    // take reciprocal for positive tick values
-    if (tick > 0) ratio = type(uint256).max / ratio;
+      // take reciprocal for positive tick values
+      if (tick > 0) ratio = type(uint256).max / ratio;
 
-    // this divides by 1<<32 rounding up to go from a Q128.128 to a Q128.96.
-    // we then downcast because we know the result always fits within 160 bits due to our tick input constraint
-    // we round up in the division so getTickAtSqrtRatio of the output price is always consistent
-    sqrtPriceX96 = uint160((ratio >> 32) + (ratio % (1 << 32) == 0 ? 0 : 1));
+      // this divides by 1<<32 rounding up to go from a Q128.128 to a Q128.96.
+      // we then downcast because we know the result always fits within 160 bits due to our tick input constraint
+      // we round up in the division so getTickAtSqrtRatio of the output price is always consistent
+      sqrtPriceX96 = uint160((ratio >> 32) + (ratio % (1 << 32) == 0 ? 0 : 1));
+    }
   }
 
   /// @notice Calculates the greatest tick value such that getRatioAtTick(tick) <= ratio
@@ -72,142 +74,144 @@ library TickMath {
     uint256 r = ratio;
     uint256 msb = 0;
 
-    assembly {
-      let f := shl(7, gt(r, 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF))
-      msb := or(msb, f)
-      r := shr(f, r)
-    }
-    assembly {
-      let f := shl(6, gt(r, 0xFFFFFFFFFFFFFFFF))
-      msb := or(msb, f)
-      r := shr(f, r)
-    }
-    assembly {
-      let f := shl(5, gt(r, 0xFFFFFFFF))
-      msb := or(msb, f)
-      r := shr(f, r)
-    }
-    assembly {
-      let f := shl(4, gt(r, 0xFFFF))
-      msb := or(msb, f)
-      r := shr(f, r)
-    }
-    assembly {
-      let f := shl(3, gt(r, 0xFF))
-      msb := or(msb, f)
-      r := shr(f, r)
-    }
-    assembly {
-      let f := shl(2, gt(r, 0xF))
-      msb := or(msb, f)
-      r := shr(f, r)
-    }
-    assembly {
-      let f := shl(1, gt(r, 0x3))
-      msb := or(msb, f)
-      r := shr(f, r)
-    }
-    assembly {
-      let f := gt(r, 0x1)
-      msb := or(msb, f)
-    }
+    unchecked {
+      assembly {
+        let f := shl(7, gt(r, 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF))
+        msb := or(msb, f)
+        r := shr(f, r)
+      }
+      assembly {
+        let f := shl(6, gt(r, 0xFFFFFFFFFFFFFFFF))
+        msb := or(msb, f)
+        r := shr(f, r)
+      }
+      assembly {
+        let f := shl(5, gt(r, 0xFFFFFFFF))
+        msb := or(msb, f)
+        r := shr(f, r)
+      }
+      assembly {
+        let f := shl(4, gt(r, 0xFFFF))
+        msb := or(msb, f)
+        r := shr(f, r)
+      }
+      assembly {
+        let f := shl(3, gt(r, 0xFF))
+        msb := or(msb, f)
+        r := shr(f, r)
+      }
+      assembly {
+        let f := shl(2, gt(r, 0xF))
+        msb := or(msb, f)
+        r := shr(f, r)
+      }
+      assembly {
+        let f := shl(1, gt(r, 0x3))
+        msb := or(msb, f)
+        r := shr(f, r)
+      }
+      assembly {
+        let f := gt(r, 0x1)
+        msb := or(msb, f)
+      }
 
-    if (msb >= 128) r = ratio >> (msb - 127);
-    else r = ratio << (127 - msb);
+      if (msb >= 128) r = ratio >> (msb - 127);
+      else r = ratio << (127 - msb);
 
-    int256 log_2 = (int256(msb) - 128) << 64;
+      int256 log_2 = (int256(msb) - 128) << 64;
 
-    assembly {
-      r := shr(127, mul(r, r))
-      let f := shr(128, r)
-      log_2 := or(log_2, shl(63, f))
-      r := shr(f, r)
-    }
-    assembly {
-      r := shr(127, mul(r, r))
-      let f := shr(128, r)
-      log_2 := or(log_2, shl(62, f))
-      r := shr(f, r)
-    }
-    assembly {
-      r := shr(127, mul(r, r))
-      let f := shr(128, r)
-      log_2 := or(log_2, shl(61, f))
-      r := shr(f, r)
-    }
-    assembly {
-      r := shr(127, mul(r, r))
-      let f := shr(128, r)
-      log_2 := or(log_2, shl(60, f))
-      r := shr(f, r)
-    }
-    assembly {
-      r := shr(127, mul(r, r))
-      let f := shr(128, r)
-      log_2 := or(log_2, shl(59, f))
-      r := shr(f, r)
-    }
-    assembly {
-      r := shr(127, mul(r, r))
-      let f := shr(128, r)
-      log_2 := or(log_2, shl(58, f))
-      r := shr(f, r)
-    }
-    assembly {
-      r := shr(127, mul(r, r))
-      let f := shr(128, r)
-      log_2 := or(log_2, shl(57, f))
-      r := shr(f, r)
-    }
-    assembly {
-      r := shr(127, mul(r, r))
-      let f := shr(128, r)
-      log_2 := or(log_2, shl(56, f))
-      r := shr(f, r)
-    }
-    assembly {
-      r := shr(127, mul(r, r))
-      let f := shr(128, r)
-      log_2 := or(log_2, shl(55, f))
-      r := shr(f, r)
-    }
-    assembly {
-      r := shr(127, mul(r, r))
-      let f := shr(128, r)
-      log_2 := or(log_2, shl(54, f))
-      r := shr(f, r)
-    }
-    assembly {
-      r := shr(127, mul(r, r))
-      let f := shr(128, r)
-      log_2 := or(log_2, shl(53, f))
-      r := shr(f, r)
-    }
-    assembly {
-      r := shr(127, mul(r, r))
-      let f := shr(128, r)
-      log_2 := or(log_2, shl(52, f))
-      r := shr(f, r)
-    }
-    assembly {
-      r := shr(127, mul(r, r))
-      let f := shr(128, r)
-      log_2 := or(log_2, shl(51, f))
-      r := shr(f, r)
-    }
-    assembly {
-      r := shr(127, mul(r, r))
-      let f := shr(128, r)
-      log_2 := or(log_2, shl(50, f))
-    }
+      assembly {
+        r := shr(127, mul(r, r))
+        let f := shr(128, r)
+        log_2 := or(log_2, shl(63, f))
+        r := shr(f, r)
+      }
+      assembly {
+        r := shr(127, mul(r, r))
+        let f := shr(128, r)
+        log_2 := or(log_2, shl(62, f))
+        r := shr(f, r)
+      }
+      assembly {
+        r := shr(127, mul(r, r))
+        let f := shr(128, r)
+        log_2 := or(log_2, shl(61, f))
+        r := shr(f, r)
+      }
+      assembly {
+        r := shr(127, mul(r, r))
+        let f := shr(128, r)
+        log_2 := or(log_2, shl(60, f))
+        r := shr(f, r)
+      }
+      assembly {
+        r := shr(127, mul(r, r))
+        let f := shr(128, r)
+        log_2 := or(log_2, shl(59, f))
+        r := shr(f, r)
+      }
+      assembly {
+        r := shr(127, mul(r, r))
+        let f := shr(128, r)
+        log_2 := or(log_2, shl(58, f))
+        r := shr(f, r)
+      }
+      assembly {
+        r := shr(127, mul(r, r))
+        let f := shr(128, r)
+        log_2 := or(log_2, shl(57, f))
+        r := shr(f, r)
+      }
+      assembly {
+        r := shr(127, mul(r, r))
+        let f := shr(128, r)
+        log_2 := or(log_2, shl(56, f))
+        r := shr(f, r)
+      }
+      assembly {
+        r := shr(127, mul(r, r))
+        let f := shr(128, r)
+        log_2 := or(log_2, shl(55, f))
+        r := shr(f, r)
+      }
+      assembly {
+        r := shr(127, mul(r, r))
+        let f := shr(128, r)
+        log_2 := or(log_2, shl(54, f))
+        r := shr(f, r)
+      }
+      assembly {
+        r := shr(127, mul(r, r))
+        let f := shr(128, r)
+        log_2 := or(log_2, shl(53, f))
+        r := shr(f, r)
+      }
+      assembly {
+        r := shr(127, mul(r, r))
+        let f := shr(128, r)
+        log_2 := or(log_2, shl(52, f))
+        r := shr(f, r)
+      }
+      assembly {
+        r := shr(127, mul(r, r))
+        let f := shr(128, r)
+        log_2 := or(log_2, shl(51, f))
+        r := shr(f, r)
+      }
+      assembly {
+        r := shr(127, mul(r, r))
+        let f := shr(128, r)
+        log_2 := or(log_2, shl(50, f))
+      }
 
-    int256 log_sqrt10001 = log_2 * 255738958999603826347141; // 128.128 number
+      int256 log_sqrt10001 = log_2 * 255738958999603826347141; // 128.128 number
 
-    int24 tickLow = int24((log_sqrt10001 - 3402992956809132418596140100660247210) >> 128);
-    int24 tickHi = int24((log_sqrt10001 + 291339464771989622907027621153398088495) >> 128);
+      int24 tickLow = int24((log_sqrt10001 - 3402992956809132418596140100660247210) >> 128);
+      int24 tickHi = int24((log_sqrt10001 + 291339464771989622907027621153398088495) >> 128);
 
-    tick = tickLow == tickHi ? tickLow : getSqrtRatioAtTick(tickHi) <= sqrtPriceX96
-      ? tickHi
-      : tickLow;
+      tick = tickLow == tickHi ? tickLow : getSqrtRatioAtTick(tickHi) <= sqrtPriceX96
+        ? tickHi
+        : tickLow;
+    }
   }
 }

--- a/contracts/mock/MockSwapMath.sol
+++ b/contracts/mock/MockSwapMath.sol
@@ -80,4 +80,36 @@ contract MockSwapMath {
       isToken0
     );
   }
+
+  function computeSwapStep(
+    uint256 liquidity,
+    uint160 currentSqrtP,
+    uint160 targetSqrtP,
+    uint256 feeInBps,
+    int256 amountRemaining,
+    bool isExactInput,
+    bool isToken0
+  )
+    external
+    view
+    returns (
+      int256 delta,
+      int256 actualDelta,
+      uint256 fee,
+      uint160 nextSqrtP,
+      uint256 gasCost
+    )
+  {
+    uint256 start = gasleft();
+    (delta, actualDelta, fee, nextSqrtP) = SwapMath.computeSwapStep(
+      liquidity,
+      currentSqrtP,
+      targetSqrtP,
+      feeInBps,
+      amountRemaining,
+      isExactInput,
+      isToken0
+    );
+    gasCost = start - gasleft();
+  }
 }

--- a/test/ProAMMPool.spec.ts
+++ b/test/ProAMMPool.spec.ts
@@ -1148,7 +1148,7 @@ describe('ProAMMPool', () => {
       it('should mint and increment pool fee growth global if rMintQty > 0', async () => {
         let userRTokenBalance = await reinvestmentToken.balanceOf(user.address);
         // do a couple of small swaps so that lf is incremented but not lfLast
-        await doRandomSwaps(pool, user, 3, MIN_LIQUIDITY);
+        await doRandomSwaps(pool, user, 3, BN.from(10_000_000));
         let reinvestmentState = await pool.getReinvestmentState();
         expect(reinvestmentState._poolReinvestmentLiquidity).to.be.gt(
           reinvestmentState._poolReinvestmentLiquidityLast

--- a/test/__snapshots__/ProAMMPool.spec.ts.snap
+++ b/test/__snapshots__/ProAMMPool.spec.ts.snap
@@ -1,25 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ProAMMPool #mint after unlockPool successful mints position above current tick #gas [ @skip-on-coverage ] 1`] = `"210720"`;
+exports[`ProAMMPool #mint after unlockPool successful mints position above current tick #gas [ @skip-on-coverage ] 1`] = `"207174"`;
 
-exports[`ProAMMPool #mint after unlockPool successful mints position above current tick #gas [ @skip-on-coverage ] 2`] = `"160076"`;
+exports[`ProAMMPool #mint after unlockPool successful mints position above current tick #gas [ @skip-on-coverage ] 2`] = `"156530"`;
 
-exports[`ProAMMPool #mint after unlockPool successful mints position includes current tick #gas [ @skip-on-coverage ] 1`] = `"241630"`;
+exports[`ProAMMPool #mint after unlockPool successful mints position includes current tick #gas [ @skip-on-coverage ] 1`] = `"237728"`;
 
-exports[`ProAMMPool #mint after unlockPool successful mints position includes current tick #gas [ @skip-on-coverage ] 2`] = `"246401"`;
+exports[`ProAMMPool #mint after unlockPool successful mints position includes current tick #gas [ @skip-on-coverage ] 2`] = `"242499"`;
 
-exports[`ProAMMPool #unlockPool #gas [ @skip-on-coverage ] 1`] = `"222576"`;
+exports[`ProAMMPool #unlockPool #gas [ @skip-on-coverage ] 1`] = `"221358"`;
 
-exports[`ProAMMPool burnRTokens init at 0 tick #gas [ @skip-on-coverage ] 1`] = `"91227"`;
+exports[`ProAMMPool burnRTokens init at 0 tick #gas [ @skip-on-coverage ] 1`] = `"89482"`;
 
-exports[`ProAMMPool swap init at reasonable tick #gas token0 exactInput - cross 2 initiated ticks [ @skip-on-coverage ] 1`] = `"248407"`;
+exports[`ProAMMPool swap init at reasonable tick #gas token0 exactInput - cross 2 initiated ticks [ @skip-on-coverage ] 1`] = `"238785"`;
 
-exports[`ProAMMPool swap init at reasonable tick #gas token0 exactInput - cross an initiated tick [ @skip-on-coverage ] 1`] = `"214916"`;
+exports[`ProAMMPool swap init at reasonable tick #gas token0 exactInput - cross an initiated tick [ @skip-on-coverage ] 1`] = `"205738"`;
 
-exports[`ProAMMPool swap init at reasonable tick #gas token0 exactInput - within a tick [ @skip-on-coverage ] 1`] = `"104514"`;
+exports[`ProAMMPool swap init at reasonable tick #gas token0 exactInput - within a tick [ @skip-on-coverage ] 1`] = `"99238"`;
 
-exports[`ProAMMPool swap init at reasonable tick #gas token1 exactOutput - cross 2 initiated ticks [ @skip-on-coverage ] 1`] = `"258746"`;
+exports[`ProAMMPool swap init at reasonable tick #gas token1 exactOutput - cross 2 initiated ticks [ @skip-on-coverage ] 1`] = `"249124"`;
 
-exports[`ProAMMPool swap init at reasonable tick #gas token1 exactOutput - cross an initiated tick [ @skip-on-coverage ] 1`] = `"225564"`;
+exports[`ProAMMPool swap init at reasonable tick #gas token1 exactOutput - cross an initiated tick [ @skip-on-coverage ] 1`] = `"216386"`;
 
-exports[`ProAMMPool swap init at reasonable tick #gas token1 exactOutput - within a tick [ @skip-on-coverage ] 1`] = `"115253"`;
+exports[`ProAMMPool swap init at reasonable tick #gas token1 exactOutput - within a tick [ @skip-on-coverage ] 1`] = `"109977"`;

--- a/test/libraries/SwapMath.spec.ts
+++ b/test/libraries/SwapMath.spec.ts
@@ -180,4 +180,18 @@ describe('SwapMath', () => {
     console.log(`finalPrice=${finalPrice.toString()} : ${sqrtPriceToString(finalPrice)}`);
     expect(finalPrice).to.lte(priceEnd); // 79623317895830914417022576523 >= 79623317895830914510639640423
   });
+
+  describe('#gas', async () => {
+    it('from token0 -> token1 exact input', async () => {
+      const liquidity = PRECISION.mul(ONE);
+      const priceStart = encodePriceSqrt(1, 1);
+      const priceEnd = encodePriceSqrt(100, 101);
+      // calculate the amount of token0 to swap from 1 -> 1 / 1.01
+      const delta = await swapMath.calcDeltaNext(liquidity, priceStart, priceEnd, fee, true, true);
+      console.log(`delta: ${delta.toString()}`); // 0.004995092120267736
+
+      const output = await swapMath.computeSwapStep(liquidity, priceStart, priceEnd, fee, delta.sub(ONE), true, true);
+      expect(output.gasCost.toString()).toMatchSnapshot();
+    });
+  });
 });

--- a/test/libraries/__snapshots__/SwapMath.spec.ts.snap
+++ b/test/libraries/__snapshots__/SwapMath.spec.ts.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SwapMath #gas from token0 -> token1 exact input 1`] = `"3453"`;


### PR DESCRIPTION
- use cache value instead of using storage value. E.g: [here](https://github.com/KyberNetwork/pro-amm/blob/25f26b6/contracts/ProAMMPool.sol#L503)
- Use local scope for variable in [here](https://github.com/KyberNetwork/pro-amm/blob/25f26b6/contracts/ProAMMPool.sol#L541)
- TickMath should be unsafe