### PR TITLE
Add coverage tests, misc fixes

### DIFF
--- a/.solcover.js
+++ b/.solcover.js
@@ -11,5 +11,6 @@ module.exports = {
     accounts: accounts
   },
   skipFiles: ['./mock', './interfaces', './misc'],
+  // including echidna files causes bad coverage reports for some reason
   istanbulReporter: ['html', 'json']
 };

--- a/contracts/ProAMMPool.sol
+++ b/contracts/ProAMMPool.sol
@@ -252,7 +252,7 @@ contract ProAMMPool is IProAMMPool, ProAMMPoolTicksState, ERC20('pro-AMM rToken'
       token1.safeTransfer(msg.sender, qty1);
     }
 
-    emit BurnLP(msg.sender, tickLower, tickUpper, qty, qty0, qty1);
+    emit Burn(msg.sender, tickLower, tickUpper, qty, qty0, qty1);
   }
 
   /// @inheritdoc IProAMMPoolActions
@@ -298,8 +298,8 @@ contract ProAMMPool is IProAMMPool, ProAMMPoolTicksState, ERC20('pro-AMM rToken'
     int24 currentTick; // the tick associated with the current price
     int24 nextTick; // the tick associated with the next price
     uint160 nextSqrtP; // the price of nextTick
-    bool isToken0; // is soureQty token0 or token1?
-    bool isExactInput; // is soureQty input or output?
+    bool isToken0; // true if deltaRemaining is in token0, false if in token1
+    bool isExactInput; // true = input qty, false = output qty
     uint128 lp; // the current pool liquidity
     uint128 lf; // the current reinvestment liquidity
     // variables below are loaded only when crossing a tick

--- a/contracts/interfaces/pool/IProAMMPoolEvents.sol
+++ b/contracts/interfaces/pool/IProAMMPoolEvents.sol
@@ -35,7 +35,7 @@ interface IProAMMPoolEvents {
   /// @param qty liquidity removed
   /// @param qty0 token0 quantity withdrawn from removal of liquidity
   /// @param qty1 token1 quantity withdrawn from removal of liquidity
-  event BurnLP(
+  event Burn(
     address indexed owner,
     int24 indexed tickLower,
     int24 indexed tickUpper,

--- a/contracts/libraries/CodeDeployer.sol
+++ b/contracts/libraries/CodeDeployer.sol
@@ -13,7 +13,8 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 pragma solidity >=0.8.0;
 
-// Taken from BalancerV2. Only modification made is the require statement.
+// Taken from BalancerV2. Only modification made is changing the require statement
+// for a failed deployment to an assert statement
 library CodeDeployer {
   // During contract construction, the full code supplied exists as code, and can be accessed via `codesize` and
   // `codecopy`. This is not the contract's final code however: whatever the constructor returns is what will be
@@ -52,8 +53,7 @@ library CodeDeployer {
 
   /**
    * @dev Deploys a contract with `code` as its code, returning the destination address.
-   *
-   * Reverts if deployment fails.
+   * Asserts that contract deployment is successful
    */
   function deploy(bytes memory code) internal returns (address destination) {
     bytes32 deployerCreationCode = _DEPLOYER_CREATION_CODE;
@@ -74,7 +74,8 @@ library CodeDeployer {
       mstore(code, codeLength)
     }
 
-    // The create opcode returns the zero address when contract creation fails, so we revert if this happens.
-    require(destination != address(0), 'deployment failed');
+    // create opcode returns null address for failed contract creation instances
+    // hence, assert that the resulting address is not null
+    assert(destination != address(0));
   }
 }

--- a/contracts/libraries/SafeCast.sol
+++ b/contracts/libraries/SafeCast.sol
@@ -11,13 +11,6 @@ library SafeCast {
     require((z = uint32(y)) == y);
   }
 
-  /// @notice Cast a uint256 to a uint160, revert on overflow
-  /// @param y The uint256 to be downcasted
-  /// @return z The downcasted integer, now type uint160
-  function toUint160(uint256 y) internal pure returns (uint160 z) {
-    require((z = uint160(y)) == y);
-  }
-
   /// @notice Cast a int256 to a int128, revert on overflow or underflow
   /// @param y The int256 to be downcasted
   /// @return z The downcasted integer, now type int128
@@ -30,6 +23,20 @@ library SafeCast {
   /// @return z The downcasted integer, now type uint128
   function toUint128(uint256 y) internal pure returns (uint128 z) {
     require((z = uint128(y)) == y);
+  }
+
+  /// @dev assume y < 0, return z = (-y)
+  function revToUint128(int128 y) internal pure returns (uint128 z) {
+    unchecked {
+      return type(uint128).max - uint128(y) + 1;
+    }
+  }
+
+  /// @notice Cast a uint256 to a uint160, revert on overflow
+  /// @param y The uint256 to be downcasted
+  /// @return z The downcasted integer, now type uint160
+  function toUint160(uint256 y) internal pure returns (uint160 z) {
+    require((z = uint160(y)) == y);
   }
 
   /// @notice Cast a uint256 to a int256, revert on overflow
@@ -52,13 +59,6 @@ library SafeCast {
   function revToUint256(int256 y) internal pure returns (uint256 z) {
     unchecked {
       return type(uint256).max - uint256(y) + 1;
-    }
-  }
-
-  /// @dev assume y <=0, return z = (-y)
-  function revToUint128(int128 y) internal pure returns (uint128 z) {
-    unchecked {
-      return type(uint128).max - uint128(y) + 1;
     }
   }
 }

--- a/contracts/libraries/SwapMath.sol
+++ b/contracts/libraries/SwapMath.sol
@@ -54,9 +54,6 @@ library SwapMath {
         isToken0
       );
       nextSqrtP = calcFinalPrice(absDelta, liquidity, fee, currentSqrtP, isExactInput, isToken0);
-      if (!isToken0 && isExactInput && nextSqrtP > targetSqrtP) {
-        nextSqrtP = targetSqrtP;
-      }
     } else {
       fee = calcStepSwapFeeAmount(
         absDelta,

--- a/contracts/mock/MockBaseSplitCodeFactory.sol
+++ b/contracts/mock/MockBaseSplitCodeFactory.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.0;
+
+import '../libraries/BaseSplitCodeFactory.sol';
+
+contract MockFactoryCreatedContract {
+  bytes32 private _id;
+
+  constructor(bytes32 id) {
+    require(id != 0, 'NON_ZERO_ID');
+    _id = id;
+  }
+
+  function getId() external view returns (bytes32) {
+    return _id;
+  }
+}
+
+contract MockSplitCodeFactory is BaseSplitCodeFactory {
+  event ContractCreated(address destination);
+  address public destination;
+
+  constructor() BaseSplitCodeFactory(type(MockFactoryCreatedContract).creationCode) {
+    // solhint-disable-previous-line no-empty-blocks
+  }
+
+  function create(bytes32 id) external returns (address) {
+    destination = _create(abi.encode(id), 0x0);
+    emit ContractCreated(destination);
+
+    return destination;
+  }
+}

--- a/contracts/mock/MockCodeDeployer.sol
+++ b/contracts/mock/MockCodeDeployer.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.0;
+
+import '../libraries/CodeDeployer.sol';
+
+contract MockCodeDeployer {
+  event CodeDeployed(address destination);
+  address public destination;
+
+  function deploy(bytes memory data) external {
+    destination = CodeDeployer.deploy(data);
+    emit CodeDeployed(destination);
+  }
+}

--- a/contracts/mock/MockSafeCast.sol
+++ b/contracts/mock/MockSafeCast.sol
@@ -4,9 +4,7 @@ pragma solidity >=0.8.0;
 import '../libraries/SafeCast.sol';
 
 contract MockSafeCast {
-  using SafeCast for uint256;
-  using SafeCast for int256;
-  using SafeCast for int128;
+  using SafeCast for *;
 
   function toUint32(uint256 y) external pure returns (uint32) {
     return y.toUint32();

--- a/contracts/mock/MockSafeCast.sol
+++ b/contracts/mock/MockSafeCast.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.0;
+
+import '../libraries/SafeCast.sol';
+
+contract MockSafeCast {
+  using SafeCast for uint256;
+  using SafeCast for int256;
+  using SafeCast for int128;
+
+  function toUint32(uint256 y) external pure returns (uint32) {
+    return y.toUint32();
+  }
+
+  function toInt128(int256 y) external pure returns (int128) {
+    return y.toInt128();
+  }
+
+  function toUint128(uint256 y) external pure returns (uint128) {
+    return y.toUint128();
+  }
+
+  function revToUint128(int128 y) external pure returns (uint128) {
+    return y.revToUint128();
+  }
+
+  function toUint160(uint256 y) external pure returns (uint160) {
+    return y.toUint160();
+  }
+
+  function toInt256(uint256 y) external pure returns (int256) {
+    return y.toInt256();
+  }
+
+  function revToInt256(uint256 y) external pure returns (int256) {
+    return y.revToInt256();
+  }
+
+  function revToUint256(int256 y) external pure returns (uint256) {
+    return y.revToUint256();
+  }
+}

--- a/contracts/periphery/NonfungiblePositionManagerSnipAttack.sol
+++ b/contracts/periphery/NonfungiblePositionManagerSnipAttack.sol
@@ -29,8 +29,8 @@ contract NonfungiblePositionManagerSnipAttack is NonfungiblePositionManager {
       uint256 amount1
     )
   {
+    (tokenId, liquidity, amount0, amount1) = super.mint(params);
     antiSnipAttackData[tokenId] = AntiSnipAttack.initialize(block.timestamp.toUint32());
-    return super.mint(params);
   }
 
   function addLiquidity(IncreaseLiquidityParams calldata params)

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -23,7 +23,8 @@ const config: HardhatUserConfig = {
     hardhat: {
       accounts: accounts,
       allowUnlimitedContractSize: true,
-      initialBaseFeePerGas: 0
+      initialBaseFeePerGas: 0,
+      gas: 15000000
     }
   },
 

--- a/test/ProAMMFactory.spec.ts
+++ b/test/ProAMMFactory.spec.ts
@@ -34,6 +34,14 @@ describe('ProAMMFactory', () => {
     tickDistance = 10;
   });
 
+  it('should return the contract creation code storage addresses', async () => {
+    const { contractA, contractB } = await factory.getCreationCodeContracts();
+    const codeA = await ethers.provider.getCode(contractA);
+    const codeB = await ethers.provider.getCode(contractB);
+    let factoryBytecode = await factory.getCreationCode();
+    expect(codeA.concat(codeB.slice(2))).to.eql(factoryBytecode);
+  });
+
   it('should have initialized with the expected settings', async () => {
     expect(await factory.configMaster()).to.eql(admin.address);
     expect(await factory.feeAmountTickSpacing(5)).to.eql(10);
@@ -97,9 +105,9 @@ describe('ProAMMFactory', () => {
     it('creates the predictable address', async () => {
       await factory.createPool(tokenA.address, tokenB.address, swapFeeBps);
       let poolAddress = await factory.getPool(tokenA.address, tokenB.address, swapFeeBps);
-      let bytescode = await factory.getCreationCode();
+      let factoryBytecode = await factory.getCreationCode();
       expect(poolAddress).to.eql(
-        getCreate2Address(factory.address, [tokenA.address, tokenB.address, swapFeeBps], bytescode)
+        getCreate2Address(factory.address, [tokenA.address, tokenB.address, swapFeeBps], factoryBytecode)
       );
     });
   });

--- a/test/ProAMMPool.spec.ts
+++ b/test/ProAMMPool.spec.ts
@@ -1227,7 +1227,7 @@ describe('ProAMMPool', () => {
 
       it('should burn liquidity with event emission', async () => {
         // note that user need not be whitelisted as burn() is not restricted
-        await expect(pool.connect(user).burn(tickLower, tickUpper, PRECISION.mul(BPS))).to.emit(pool, 'BurnLP');
+        await expect(pool.connect(user).burn(tickLower, tickUpper, PRECISION.mul(BPS))).to.emit(pool, 'Burn');
         const {liquidity} = await pool.getPositions(user.address, tickLower, tickUpper);
         expect(liquidity).to.be.eql(ZERO);
       });

--- a/test/ProAMMPool.spec.ts
+++ b/test/ProAMMPool.spec.ts
@@ -61,7 +61,7 @@ let vestingPeriod = 100;
 
 let minTick = getMinTick(tickDistance);
 let maxTick = getMaxTick(tickDistance);
-let ticksPrevious = [MIN_TICK, MIN_TICK];
+let ticksPrevious: [BN, BN] = [MIN_TICK, MIN_TICK];
 let initialPrice: BN;
 let nearestTickToPrice: number; // the floor of tick that mod tickDistance = 0
 let tickLower: number;

--- a/test/__snapshots__/ProAMMPool.spec.ts.snap
+++ b/test/__snapshots__/ProAMMPool.spec.ts.snap
@@ -14,14 +14,14 @@ exports[`ProAMMPool #unlockPool #gas [ @skip-on-coverage ] 1`] = `"234230"`;
 
 exports[`ProAMMPool burnRTokens init at 0 tick #gas [ @skip-on-coverage ] 1`] = `"78686"`;
 
-exports[`ProAMMPool swap init at reasonable tick #gas token0 exactInput - cross 2 initiated ticks [ @skip-on-coverage ] 1`] = `"211163"`;
+exports[`ProAMMPool swap init at reasonable tick #gas token0 exactInput - cross 2 initiated ticks [ @skip-on-coverage ] 1`] = `"211100"`;
 
-exports[`ProAMMPool swap init at reasonable tick #gas token0 exactInput - cross an initiated tick [ @skip-on-coverage ] 1`] = `"177286"`;
+exports[`ProAMMPool swap init at reasonable tick #gas token0 exactInput - cross an initiated tick [ @skip-on-coverage ] 1`] = `"177223"`;
 
-exports[`ProAMMPool swap init at reasonable tick #gas token0 exactInput - within a tick [ @skip-on-coverage ] 1`] = `"97725"`;
+exports[`ProAMMPool swap init at reasonable tick #gas token0 exactInput - within a tick [ @skip-on-coverage ] 1`] = `"97662"`;
 
-exports[`ProAMMPool swap init at reasonable tick #gas token1 exactOutput - cross 2 initiated ticks [ @skip-on-coverage ] 1`] = `"221629"`;
+exports[`ProAMMPool swap init at reasonable tick #gas token1 exactOutput - cross 2 initiated ticks [ @skip-on-coverage ] 1`] = `"221561"`;
 
-exports[`ProAMMPool swap init at reasonable tick #gas token1 exactOutput - cross an initiated tick [ @skip-on-coverage ] 1`] = `"188058"`;
+exports[`ProAMMPool swap init at reasonable tick #gas token1 exactOutput - cross an initiated tick [ @skip-on-coverage ] 1`] = `"187990"`;
 
-exports[`ProAMMPool swap init at reasonable tick #gas token1 exactOutput - within a tick [ @skip-on-coverage ] 1`] = `"108585"`;
+exports[`ProAMMPool swap init at reasonable tick #gas token1 exactOutput - within a tick [ @skip-on-coverage ] 1`] = `"108517"`;

--- a/test/helpers/hardhat.ts
+++ b/test/helpers/hardhat.ts
@@ -1,6 +1,10 @@
 import {BigNumber as BN, BigNumberish} from 'ethers';
 import hardhat from 'hardhat';
 
+import {Artifacts} from 'hardhat/internal/artifacts';
+import {Artifact} from 'hardhat/types';
+import path from 'path';
+
 export async function runWithImpersonation(target: string, run: () => Promise<void>): Promise<void> {
   await hardhat.network.provider.request({
     method: 'hardhat_impersonateAccount',
@@ -63,4 +67,11 @@ export async function getLatestBlockTime() {
     params: ['latest', false],
   });
   return BN.from(result.timestamp).toNumber();
+}
+
+export async function getArtifact(contract: string): Promise<Artifact> {
+  let artifactsPath: string;
+  artifactsPath = path.resolve('./artifacts');
+  const artifacts = new Artifacts(artifactsPath);
+  return artifacts.readArtifact(contract.split('/').slice(-1)[0]);
 }

--- a/test/libraries/BaseSplitCodeFactory.spec.ts
+++ b/test/libraries/BaseSplitCodeFactory.spec.ts
@@ -1,0 +1,68 @@
+import {ethers, waffle} from 'hardhat';
+import {expect} from 'chai';
+import chai from 'chai';
+const {solidity, loadFixture} = waffle;
+chai.use(solidity);
+
+import {MockSplitCodeFactory, MockSplitCodeFactory__factory} from '../../typechain';
+import {getArtifact} from '../helpers/hardhat';
+
+let factory: MockSplitCodeFactory;
+let Factory: MockSplitCodeFactory__factory;
+let contract: string;
+const INVALID_ID = '0x0000000000000000000000000000000000000000000000000000000000000000';
+const id = '0x0123456789012345678901234567890123456789012345678901234567890123';
+
+describe('BaseSplitCodeFactory', () => {
+  async function fixture() {
+    Factory = (await ethers.getContractFactory('MockSplitCodeFactory')) as MockSplitCodeFactory__factory;
+    return await Factory.deploy();
+  }
+
+  beforeEach('load fixture', async () => {
+    factory = await loadFixture(fixture);
+  });
+
+  it('returns the contract creation code storage addresses', async () => {
+    const {contractA, contractB} = await factory.getCreationCodeContracts();
+
+    const codeA = await ethers.provider.getCode(contractA);
+    const codeB = await ethers.provider.getCode(contractB);
+
+    const artifact = await getArtifact('MockFactoryCreatedContract');
+    expect(codeA.concat(codeB.slice(2))).to.equal(artifact.bytecode); // Slice to remove the '0x' prefix
+  });
+
+  it('returns the contract creation code', async () => {
+    const artifact = await getArtifact('MockFactoryCreatedContract');
+    const poolCreationCode = await factory.getCreationCode();
+
+    expect(poolCreationCode).to.equal(artifact.bytecode);
+  });
+
+  it('creates a contract', async () => {
+    await expect(factory.create(id)).to.emit(factory, 'ContractCreated');
+  });
+
+  it('reverts and bubbles up revert reasons', async () => {
+    await expect(factory.create(INVALID_ID)).to.be.revertedWith('NON_ZERO_ID');
+  });
+
+  describe('with created pool', async () => {
+    beforeEach('create contract', async () => {
+      await factory.create(id);
+      contract = await factory.destination();
+    });
+
+    it('deploys correct bytecode', async () => {
+      const code = await ethers.provider.getCode(contract);
+      const artifact = await getArtifact('MockFactoryCreatedContract');
+      expect(code).to.equal(artifact.deployedBytecode);
+    });
+
+    it('passes constructor arguments correctly', async () => {
+      const contractObject = await ethers.getContractAt('MockFactoryCreatedContract', contract);
+      expect(await contractObject.getId()).to.equal(id);
+    });
+  });
+});

--- a/test/libraries/CodeDeployer.spec.ts
+++ b/test/libraries/CodeDeployer.spec.ts
@@ -1,0 +1,42 @@
+import {ethers, waffle} from 'hardhat';
+import {expect} from 'chai';
+import chai from 'chai';
+const {solidity, loadFixture} = waffle;
+chai.use(solidity);
+
+import {MockCodeDeployer, MockCodeDeployer__factory} from '../../typechain';
+
+let codeDeployer: MockCodeDeployer;
+let CodeDeployer: MockCodeDeployer__factory;
+let contract: string;
+const INVALID_ID = '0x0000000000000000000000000000000000000000000000000000000000000000';
+const id = '0x0123456789012345678901234567890123456789012345678901234567890123';
+
+describe('CodeDeployer', () => {
+  async function fixture() {
+    CodeDeployer = (await ethers.getContractFactory('MockCodeDeployer')) as MockCodeDeployer__factory;
+    return await CodeDeployer.deploy();
+  }
+
+  beforeEach('load fixture', async () => {
+    codeDeployer = await loadFixture(fixture);
+  });
+
+  it('deploys with no code', async () => {
+    await deployCodeAndVerify('0x');
+  });
+
+  it('deploys with some code', async () => {
+    await deployCodeAndVerify('0x1234');
+  });
+
+  it('deploys code with maximum length (24kb) ', async () => {
+    await deployCodeAndVerify(`0x${'ff'.repeat(24 * 1024)}`);
+  });
+});
+
+async function deployCodeAndVerify(data: string) {
+  await codeDeployer.deploy(data);
+  let destination = await codeDeployer.destination();
+  expect(await ethers.provider.getCode(destination)).to.be.eq(data);
+}

--- a/test/libraries/CodeDeployer.spec.ts
+++ b/test/libraries/CodeDeployer.spec.ts
@@ -8,9 +8,6 @@ import {MockCodeDeployer, MockCodeDeployer__factory} from '../../typechain';
 
 let codeDeployer: MockCodeDeployer;
 let CodeDeployer: MockCodeDeployer__factory;
-let contract: string;
-const INVALID_ID = '0x0000000000000000000000000000000000000000000000000000000000000000';
-const id = '0x0123456789012345678901234567890123456789012345678901234567890123';
 
 describe('CodeDeployer', () => {
   async function fixture() {

--- a/test/libraries/SafeCast.spec.ts
+++ b/test/libraries/SafeCast.spec.ts
@@ -1,0 +1,169 @@
+import {ethers, waffle} from 'hardhat';
+import {expect} from 'chai';
+import chai from 'chai';
+import {MAX_INT_128, MAX_UINT, MIN_INT_128, ONE, TWO} from '../helpers/helper';
+const {solidity} = waffle;
+chai.use(solidity);
+
+import {MockSafeCast, MockSafeCast__factory} from '../../typechain';
+
+let safeCast: MockSafeCast;
+let SafeCast: MockSafeCast__factory;
+let bits: number;
+
+describe('SafeCast', () => {
+  before('setup', async () => {
+    SafeCast = (await ethers.getContractFactory('MockSafeCast')) as MockSafeCast__factory;
+    safeCast = await SafeCast.deploy();
+  });
+
+  [32, 128, 160].forEach((bits) => testToUint(bits));
+
+  function testToUint(bits: number) {
+    describe(`uint256 -> toUint${bits}`, async () => {
+      const maxValue = TWO.pow(bits).sub(ONE);
+
+      it('should downcast 0', async () => {
+        expect(await safeCast[`toUint${bits}`](0)).to.be.eq(0);
+      });
+
+      it('should downcast 1', async () => {
+        expect(await safeCast[`toUint${bits}`](1)).to.be.eq(1);
+      });
+
+      it(`should downcast 2^${bits} - 1 (${maxValue})`, async () => {
+        expect(await safeCast[`toUint${bits}`](maxValue)).to.be.eq(maxValue);
+      });
+
+      it(`should revert when downcasting 2^${bits} (${maxValue.add(ONE)})`, async () => {
+        await expect(safeCast[`toUint${bits}`](maxValue.add(ONE))).to.be.reverted;
+      });
+
+      it(`should revert when downcasting 2^${bits} + 1 (${maxValue.add(TWO)})`, async () => {
+        await expect(safeCast[`toUint${bits}`](maxValue.add(TWO))).to.be.reverted;
+      });
+    });
+  }
+
+  [128, 256].forEach((bits) => testRevToUint(bits));
+
+  function testRevToUint(bits: number) {
+    describe(`int${bits} -> revToUint${bits}`, async () => {
+      const minValue = TWO.pow(bits - 1).mul(-1);
+      const maxValue = TWO.pow(bits - 1).sub(ONE);
+
+      it(`should cast 0`, async () => {
+        expect(await safeCast[`revToUint${bits}`](0)).to.be.eq(0);
+      });
+
+      it(`should return 1 for -1`, async () => {
+        expect(await safeCast[`revToUint${bits}`](-1)).to.be.eq(1);
+      });
+
+      it(`should return 2^${bits - 1} for -2^${bits - 1} (${minValue})`, async () => {
+        expect(await safeCast[`revToUint${bits}`](minValue)).to.be.eq(minValue.mul(-1));
+      });
+
+      it(`will return 2^${bits} - 1 for 1`, async () => {
+        expect(await safeCast[`revToUint${bits}`](1)).to.be.eq(TWO.pow(bits).sub(ONE));
+      });
+
+      it(`will return 2^${bits} + 1 for 2^${bits} - 1 (${maxValue})`, async () => {
+        expect(await safeCast[`revToUint${bits}`](maxValue)).to.be.eq(maxValue.add(TWO));
+      });
+    });
+  }
+
+  describe(`int256 -> toInt128`, async () => {
+    const minValue = MIN_INT_128;
+    const maxValue = MAX_INT_128;
+
+    it('should downcast 0', async function () {
+      expect(await safeCast.toInt128(0)).to.be.eq(0);
+    });
+
+    it('should downcast 1', async function () {
+      expect(await safeCast.toInt128(1)).to.be.eq(1);
+    });
+
+    it('should downcast -1', async function () {
+      expect(await safeCast.toInt128(-1)).to.be.eq(-1);
+    });
+
+    it(`should downcast -2^127 (${minValue})`, async function () {
+      expect(await safeCast.toInt128(minValue)).to.be.eq(minValue);
+    });
+
+    it(`should downcast 2^127 - 1 (${maxValue})`, async function () {
+      expect(await safeCast.toInt128(maxValue)).to.be.eq(maxValue);
+    });
+
+    it(`reverts when downcasting -2^127 - 1 (${minValue.sub(ONE)})`, async function () {
+      await expect(safeCast.toInt128(minValue.sub(ONE))).to.be.reverted;
+    });
+
+    it(`reverts when downcasting -2^127 - 2 (${minValue.sub(TWO)})`, async () => {
+      await expect(safeCast.toInt128(minValue.sub(TWO))).to.be.reverted;
+    });
+
+    it(`reverts when downcasting 2^127 (${maxValue.add(ONE)})`, async () => {
+      await expect(safeCast.toInt128(maxValue.add(ONE))).to.be.reverted;
+    });
+
+    it(`reverts when downcasting 2^127 + 1 (${maxValue.add(TWO)})`, async () => {
+      await expect(safeCast.toInt128(maxValue.add(TWO))).to.be.reverted;
+    });
+  });
+
+  describe(`uint256 -> toint256`, async () => {
+    const maxValue = TWO.pow(255).sub(ONE);
+
+    it('should downcast 0', async function () {
+      expect(await safeCast.toInt256(0)).to.be.eq(0);
+    });
+
+    it('should downcast 1', async function () {
+      expect(await safeCast.toInt256(1)).to.be.eq(1);
+    });
+
+    it(`should downcast 2^255 - 1 (${maxValue})`, async () => {
+      expect(await safeCast.toInt256(maxValue)).to.be.eq(maxValue);
+    });
+
+    it(`reverts when downcasting 2^255 (${maxValue.add(ONE)})`, async () => {
+      await expect(safeCast.toInt256(maxValue.add(ONE))).to.be.reverted;
+    });
+
+    it(`reverts when downcasting 2^255 + 1 (${maxValue.add(TWO)})`, async () => {
+      await expect(safeCast.toInt256(maxValue.add(TWO))).to.be.reverted;
+    });
+  });
+
+  describe(`uint256 -> revToInt256`, async () => {
+    const maxValue = TWO.pow(255).sub(ONE);
+
+    it('should cast 0', async () => {
+      expect(await safeCast.revToInt256(0)).to.be.eq(0);
+    });
+
+    it(`should return -1 for 1`, async () => {
+      expect(await safeCast.revToInt256(1)).to.be.eq(-1);
+    });
+
+    it(`should return -(2^255 - 1) for 2^255 - 1 (${maxValue})`, async () => {
+      expect(await safeCast.revToInt256(maxValue)).to.be.eq(maxValue.mul(-1));
+    });
+
+    it(`reverts for 2^255 (${maxValue.add(ONE)})`, async () => {
+      await expect(safeCast.revToInt256(maxValue.add(ONE))).to.be.reverted;
+    });
+
+    it(`reverts for 2^255 + 1 (${maxValue.add(TWO)})`, async () => {
+      await expect(safeCast.revToInt256(maxValue.add(TWO))).to.be.reverted;
+    });
+
+    it(`reverts for MAX_UINT (2^256 - 1)`, async () => {
+      await expect(safeCast.revToInt256(MAX_UINT)).to.be.reverted;
+    });
+  });
+});

--- a/test/libraries/__snapshots__/SwapMath.spec.ts.snap
+++ b/test/libraries/__snapshots__/SwapMath.spec.ts.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SwapMath #gas [ @skip-on-coverage ] from token0 -> token1 exact input 1`] = `"3547"`;
+exports[`SwapMath #gas [ @skip-on-coverage ] from token0 -> token1 exact input 1`] = `"3484"`;

--- a/test/periphery/LiquidityHelper.spec.ts
+++ b/test/periphery/LiquidityHelper.spec.ts
@@ -138,9 +138,7 @@ describe('LiquidityHelper', () => {
       for (let i = 0; i < firstTokens.length; i++) {
         let index = i % swapFeeBpsArray.length;
         let fee = swapFeeBpsArray[index];
-
-        let token0 = firstTokens[i] < secondTokens[i] ? firstTokens[i] : secondTokens[i];
-        let token1 = firstTokens[i] < secondTokens[i] ? secondTokens[i] : firstTokens[i];
+        let [token0, token1] = sortTokens(firstTokens[i], secondTokens[i]);
 
         let pool = await createPool(token0, token1, swapFeeBpsArray[index]);
         await liquidityHelper.connect(user).testUnlockPool(token0, token1, swapFeeBpsArray[index], initialPrice);
@@ -179,8 +177,7 @@ describe('LiquidityHelper', () => {
       let userBefore = await getBalances(user.address, [ZERO_ADDRESS, weth.address, tokenA.address]);
       let poolBefore = await getBalances(pool.address, [ZERO_ADDRESS, weth.address, tokenA.address]);
 
-      let token0 = weth.address < tokenA.address ? weth.address : tokenA.address;
-      let token1 = weth.address > tokenA.address ? weth.address : tokenA.address;
+      let [token0, token1] = sortTokens(weth.address, tokenA.address);
 
       let params = {
         token0: token0,

--- a/test/periphery/NonFungiblePositionManager.spec.ts
+++ b/test/periphery/NonFungiblePositionManager.spec.ts
@@ -13,7 +13,7 @@ import {MockTokenPositionDescriptor, MockTokenPositionDescriptor__factory} from 
 
 import {deployFactory, getTicksPrevious} from '../helpers/proAMMSetup';
 import {snapshot, revertToSnapshot} from '../helpers/hardhat';
-import {BN, PRECISION, ZERO_ADDRESS, TWO_POW_96, MIN_INT, MIN_TICK} from '../helpers/helper';
+import {BN, PRECISION, ZERO_ADDRESS, TWO_POW_96, MIN_TICK} from '../helpers/helper';
 import {encodePriceSqrt, sortTokens} from '../helpers/utils';
 import getEC721PermitSignature from '../helpers/getEC721PermitSignature';
 
@@ -36,7 +36,7 @@ let weth: MockWeth;
 let nextTokenId: BigNumber;
 let swapFeeBpsArray = [5, 30];
 let tickDistanceArray = [10, 60];
-let ticksPrevious = [MIN_TICK, MIN_TICK];
+let ticksPrevious: [BigNumber, BigNumber] = [MIN_TICK, MIN_TICK];
 let vestingPeriod = 0;
 let initialPrice: BigNumber;
 let snapshotId: any;

--- a/test/periphery/NonFungiblePositionManagerSnipAttack.spec.ts
+++ b/test/periphery/NonFungiblePositionManagerSnipAttack.spec.ts
@@ -1,6 +1,6 @@
 import {ethers, waffle} from 'hardhat';
 import {expect} from 'chai';
-import {Wallet, BigNumber, ContractTransaction} from 'ethers';
+import {BigNumber} from 'ethers';
 import chai from 'chai';
 const {solidity} = waffle;
 chai.use(solidity);
@@ -15,16 +15,14 @@ import {
   ProAMMRouter__factory,
   ProAMMRouter,
   ProAMMFactory,
-  ProAMMPool,
   MockTokenPositionDescriptor,
   MockTokenPositionDescriptor__factory,
 } from '../../typechain';
 
 import {deployFactory} from '../helpers/proAMMSetup';
 import {snapshot, revertToSnapshot} from '../helpers/hardhat';
-import {BN, PRECISION, ZERO_ADDRESS, TWO_POW_96, ZERO} from '../helpers/helper';
+import {BN, PRECISION, ZERO, MIN_TICK} from '../helpers/helper';
 import {encodePriceSqrt, sortTokens} from '../helpers/utils';
-import getEC721PermitSignature from '../helpers/getEC721PermitSignature';
 
 const txGasPrice = BN.from(100).mul(BN.from(10).pow(9));
 const showTxGasUsed = true;
@@ -45,12 +43,13 @@ let weth: MockWeth;
 let nextTokenId: BigNumber;
 let swapFeeBpsArray = [5, 30];
 let tickDistanceArray = [10, 60];
+let ticksPrevious: [BigNumber, BigNumber] = [MIN_TICK, MIN_TICK];
 let vestingPeriod = 100;
 let initialPrice: BigNumber;
 let snapshotId: any;
 let initialSnapshotId: any;
 
-describe('NonFungiblePositionManager', () => {
+describe('NonFungiblePositionManagerSnipAttack', () => {
   const [user, admin] = waffle.provider.getWallets();
   const tickLower = -100 * tickDistanceArray[0];
   const tickUpper = 100 * tickDistanceArray[0];
@@ -143,6 +142,7 @@ describe('NonFungiblePositionManager', () => {
         fee: swapFeeBpsArray[0],
         tickLower: tickLower,
         tickUpper: tickUpper,
+        ticksPrevious: ticksPrevious,
         amount0Desired: BN.from(1000000),
         amount1Desired: BN.from(1000000),
         amount0Min: 0,

--- a/test/periphery/NonFungiblePositionManagerSnipAttack.spec.ts
+++ b/test/periphery/NonFungiblePositionManagerSnipAttack.spec.ts
@@ -1,0 +1,161 @@
+import {ethers, waffle} from 'hardhat';
+import {expect} from 'chai';
+import {Wallet, BigNumber, ContractTransaction} from 'ethers';
+import chai from 'chai';
+const {solidity} = waffle;
+chai.use(solidity);
+
+import {
+  MockToken,
+  MockToken__factory,
+  MockWeth,
+  MockWeth__factory,
+  NonfungiblePositionManagerSnipAttack,
+  NonfungiblePositionManagerSnipAttack__factory,
+  ProAMMRouter__factory,
+  ProAMMRouter,
+  ProAMMFactory,
+  ProAMMPool,
+  MockTokenPositionDescriptor,
+  MockTokenPositionDescriptor__factory,
+} from '../../typechain';
+
+import {deployFactory} from '../helpers/proAMMSetup';
+import {snapshot, revertToSnapshot} from '../helpers/hardhat';
+import {BN, PRECISION, ZERO_ADDRESS, TWO_POW_96, ZERO} from '../helpers/helper';
+import {encodePriceSqrt, sortTokens} from '../helpers/utils';
+import getEC721PermitSignature from '../helpers/getEC721PermitSignature';
+
+const txGasPrice = BN.from(100).mul(BN.from(10).pow(9));
+const showTxGasUsed = true;
+
+const BIG_AMOUNT = BN.from(2).pow(255);
+
+let Token: MockToken__factory;
+let PositionManager: NonfungiblePositionManagerSnipAttack__factory;
+let factory: ProAMMFactory;
+let positionManager: NonfungiblePositionManagerSnipAttack;
+let router: ProAMMRouter;
+let tokenDescriptor: MockTokenPositionDescriptor;
+let tokenA: MockToken;
+let tokenB: MockToken;
+let token0: string;
+let token1: string;
+let weth: MockWeth;
+let nextTokenId: BigNumber;
+let swapFeeBpsArray = [5, 30];
+let tickDistanceArray = [10, 60];
+let vestingPeriod = 100;
+let initialPrice: BigNumber;
+let snapshotId: any;
+let initialSnapshotId: any;
+
+describe('NonFungiblePositionManager', () => {
+  const [user, admin] = waffle.provider.getWallets();
+  const tickLower = -100 * tickDistanceArray[0];
+  const tickUpper = 100 * tickDistanceArray[0];
+
+  before('factory, token and callback setup', async () => {
+    Token = (await ethers.getContractFactory('MockToken')) as MockToken__factory;
+    tokenA = await Token.deploy('USDC', 'USDC', BN.from(100000000000).mul(PRECISION));
+    tokenB = await Token.deploy('DAI', 'DAI', BN.from(100000000000).mul(PRECISION));
+    factory = await deployFactory(admin, vestingPeriod);
+
+    const WETH = (await ethers.getContractFactory('MockWeth')) as MockWeth__factory;
+    weth = await WETH.deploy();
+
+    const Descriptor = (await ethers.getContractFactory(
+      'MockTokenPositionDescriptor'
+    )) as MockTokenPositionDescriptor__factory;
+    tokenDescriptor = await Descriptor.deploy();
+
+    PositionManager = (await ethers.getContractFactory(
+      'NonfungiblePositionManagerSnipAttack'
+    )) as NonfungiblePositionManagerSnipAttack__factory;
+    positionManager = await PositionManager.deploy(factory.address, weth.address, tokenDescriptor.address);
+    await factory.connect(admin).addNFTManager(positionManager.address);
+
+    const Router = (await ethers.getContractFactory('ProAMMRouter')) as ProAMMRouter__factory;
+    router = await Router.deploy(factory.address, weth.address);
+
+    // add any newly defined tickDistance apart from default ones
+    for (let i = 0; i < swapFeeBpsArray.length; i++) {
+      if ((await factory.feeAmountTickSpacing(swapFeeBpsArray[i])) == 0) {
+        await factory.connect(admin).enableSwapFee(swapFeeBpsArray[i], tickDistanceArray[i]);
+      }
+    }
+
+    initialPrice = encodePriceSqrt(1, 1);
+
+    await weth.connect(user).deposit({value: PRECISION.mul(10)});
+
+    await weth.connect(user).approve(positionManager.address, BIG_AMOUNT);
+    await tokenA.connect(user).approve(positionManager.address, BIG_AMOUNT);
+    await tokenB.connect(user).approve(positionManager.address, BIG_AMOUNT);
+
+    await weth.connect(user).approve(router.address, BIG_AMOUNT);
+    await tokenA.connect(user).approve(router.address, BIG_AMOUNT);
+    await tokenB.connect(user).approve(router.address, BIG_AMOUNT);
+
+    await tokenA.transfer(user.address, PRECISION.mul(2000000));
+    await tokenB.transfer(user.address, PRECISION.mul(2000000));
+
+    [token0, token1] = sortTokens(tokenA.address, tokenB.address);
+
+    initialSnapshotId = await snapshot();
+    snapshotId = initialSnapshotId;
+  });
+
+  const createAndUnlockPools = async () => {
+    let initialPrice = encodePriceSqrt(1, 1);
+    let [token0, token1] = sortTokens(tokenA.address, tokenB.address);
+    await positionManager
+      .connect(user)
+      .createAndUnlockPoolIfNecessary(token0, token1, swapFeeBpsArray[0], initialPrice);
+    [token0, token1] = sortTokens(tokenA.address, weth.address);
+    await positionManager
+      .connect(user)
+      .createAndUnlockPoolIfNecessary(token0, token1, swapFeeBpsArray[0], initialPrice);
+    [token0, token1] = sortTokens(tokenB.address, weth.address);
+    await positionManager
+      .connect(user)
+      .createAndUnlockPoolIfNecessary(token0, token1, swapFeeBpsArray[0], initialPrice);
+  };
+
+  describe(`#mint`, async () => {
+    before('create and unlock pools', async () => {
+      await revertToSnapshot(initialSnapshotId);
+      await createAndUnlockPools();
+      snapshotId = await snapshot();
+    });
+
+    beforeEach('revert to snapshot', async () => {
+      await revertToSnapshot(snapshotId);
+      snapshotId = await snapshot();
+      nextTokenId = await positionManager.nextTokenId();
+    });
+
+    it('should initialize antiSnipAttackData for the minted position', async () => {
+      let _nextTokenId = nextTokenId;
+      await positionManager.connect(user).mint({
+        token0: token0,
+        token1: token1,
+        fee: swapFeeBpsArray[0],
+        tickLower: tickLower,
+        tickUpper: tickUpper,
+        amount0Desired: BN.from(1000000),
+        amount1Desired: BN.from(1000000),
+        amount0Min: 0,
+        amount1Min: 0,
+        recipient: user.address,
+        deadline: PRECISION,
+      });
+
+      let antiSnipAttackData = await positionManager.antiSnipAttackData(_nextTokenId);
+      expect(antiSnipAttackData.lastActionTime).to.be.gt(ZERO);
+      expect(antiSnipAttackData.lockTime).to.be.gt(ZERO);
+      expect(antiSnipAttackData.unlockTime).to.be.gt(ZERO);
+      expect(antiSnipAttackData.feesLocked).to.be.eq(ZERO);
+    });
+  });
+});

--- a/test/periphery/ProAMMRouter.spec.ts
+++ b/test/periphery/ProAMMRouter.spec.ts
@@ -31,7 +31,7 @@ let callback: MockProAMMCallbacks;
 let vestingPeriod = 100;
 let swapFeeBpsArray = [5, 30];
 let tickDistanceArray = [10, 60];
-let ticksPrevious = [MIN_TICK, MIN_TICK];
+let ticksPrevious: [BN, BN] = [MIN_TICK, MIN_TICK];
 let initialPrice: BN;
 let ticks: number[];
 

--- a/test/periphery/Quoterv2.spec.ts
+++ b/test/periphery/Quoterv2.spec.ts
@@ -17,7 +17,7 @@ import {MockProAMMCallbacks2, MockProAMMCallbacks2__factory} from '../../typecha
 let swapFeeBpsArray = [5, 2];
 let tickDistanceArray = [10, 6];
 let vestingPeriod = 100;
-let ticksPrevious = [MIN_TICK, MIN_TICK];
+let ticksPrevious: [BN, BN] = [MIN_TICK, MIN_TICK];
 
 class Fixtures {
   constructor(

--- a/test/periphery/__snapshots__/ProAMMRouter.spec.ts.snap
+++ b/test/periphery/__snapshots__/ProAMMRouter.spec.ts.snap
@@ -1,21 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ProAMMRouter #swapExactInput #gas 2 pool [ @skip-on-coverage ] 1`] = `"183854"`;
+exports[`ProAMMRouter #swapExactInput #gas 2 pool [ @skip-on-coverage ] 1`] = `"183944"`;
 
-exports[`ProAMMRouter #swapExactInput #gas one pool [ @skip-on-coverage ] 1`] = `"108965"`;
+exports[`ProAMMRouter #swapExactInput #gas one pool [ @skip-on-coverage ] 1`] = `"109002"`;
 
-exports[`ProAMMRouter #swapExactInput #gas one pool [ @skip-on-coverage ] 2`] = `"113780"`;
+exports[`ProAMMRouter #swapExactInput #gas one pool [ @skip-on-coverage ] 2`] = `"113809"`;
 
-exports[`ProAMMRouter #swapExactInput #gas one pool [ @skip-on-coverage ] 3`] = `"109049"`;
+exports[`ProAMMRouter #swapExactInput #gas one pool [ @skip-on-coverage ] 3`] = `"109074"`;
 
-exports[`ProAMMRouter #swapExactInput #gas one pool [ @skip-on-coverage ] 4`] = `"113792"`;
+exports[`ProAMMRouter #swapExactInput #gas one pool [ @skip-on-coverage ] 4`] = `"113809"`;
 
-exports[`ProAMMRouter #swapExactOutput #gas 2 pool [ @skip-on-coverage ] 1`] = `"198619"`;
+exports[`ProAMMRouter #swapExactOutput #gas 2 pool [ @skip-on-coverage ] 1`] = `"198880"`;
 
-exports[`ProAMMRouter #swapExactOutput #gas one pool [ @skip-on-coverage ] 1`] = `"120664"`;
+exports[`ProAMMRouter #swapExactOutput #gas one pool [ @skip-on-coverage ] 1`] = `"120769"`;
 
-exports[`ProAMMRouter #swapExactOutput #gas one pool [ @skip-on-coverage ] 2`] = `"125561"`;
+exports[`ProAMMRouter #swapExactOutput #gas one pool [ @skip-on-coverage ] 2`] = `"125709"`;
 
-exports[`ProAMMRouter #swapExactOutput #gas one pool [ @skip-on-coverage ] 3`] = `"120748"`;
+exports[`ProAMMRouter #swapExactOutput #gas one pool [ @skip-on-coverage ] 3`] = `"120841"`;
 
-exports[`ProAMMRouter #swapExactOutput #gas one pool [ @skip-on-coverage ] 4`] = `"125573"`;
+exports[`ProAMMRouter #swapExactOutput #gas one pool [ @skip-on-coverage ] 4`] = `"125709"`;


### PR DESCRIPTION
- Fix SnipAttack NFT Manager `mint()` to use `nextTokenId` instead of `tokenId`
- `BurnLP` -> `Burn`
- Change `require` statement in CodeDeployer to `assert`
- Edge case removal in SwapMath
- Inline comment edits
- Coverage for:
   - `SnippingAttack`
   - `BaseSplitCodeFactory`
   - `SafeCast`
