### PR TITLE
Gas inefficiency in insert() of LinkedList

### DIFF
--- a/contracts/PoolTicksState.sol
+++ b/contracts/PoolTicksState.sol
@@ -246,7 +246,7 @@ contract PoolTicksState is PoolStorage {
         nextTick = initializedTicks[previousTick].next;
         iteration++;
       }
-      initializedTicks.insert(tick, previousTick);
+      initializedTicks.insert(tick, previousTick, nextTick);
       if (poolData.nearestCurrentTick < tick && tick <= currentTick) {
         poolData.nearestCurrentTick = tick;
       }

--- a/contracts/libraries/Linkedlist.sol
+++ b/contracts/libraries/Linkedlist.sol
@@ -46,11 +46,7 @@ library Linkedlist {
     int24 nextValue
   ) internal {
     require(nextValue != self[lowerValue].previous, 'lower value is not initialized');
-    require(lowerValue < newValue && self[lowerValue].next > newValue, 'invalid lower value');
-    require(
-      nextValue == self[lowerValue].next && lowerValue == self[nextValue].previous,
-      'invalid next value'
-    );
+    require(lowerValue < newValue && nextValue > newValue, 'invalid lower value');
     self[newValue].next = nextValue;
     self[newValue].previous = lowerValue;
     self[nextValue].previous = newValue;

--- a/contracts/libraries/Linkedlist.sol
+++ b/contracts/libraries/Linkedlist.sol
@@ -42,11 +42,15 @@ library Linkedlist {
   function insert(
     mapping(int24 => Linkedlist.Data) storage self,
     int24 newValue,
-    int24 lowerValue
+    int24 lowerValue,
+    int24 nextValue
   ) internal {
-    int24 nextValue = self[lowerValue].next;
     require(nextValue != self[lowerValue].previous, 'lower value is not initialized');
-    require(lowerValue < newValue && nextValue > newValue, 'invalid lower value');
+    require(lowerValue < newValue && self[lowerValue].next > newValue, 'invalid lower value');
+    require(
+      nextValue == self[lowerValue].next && lowerValue == self[nextValue].previous,
+      'invalid next value'
+    );
     self[newValue].next = nextValue;
     self[newValue].previous = lowerValue;
     self[nextValue].previous = newValue;

--- a/contracts/mock/MockLinkedlist.sol
+++ b/contracts/mock/MockLinkedlist.sol
@@ -13,8 +13,12 @@ contract MockLinkedlist {
     values.init(minValue, maxValue);
   }
 
-  function insert(int24 newValue, int24 nearestLower) external {
-    values.insert(newValue, nearestLower);
+  function insert(
+    int24 newValue,
+    int24 nearestLower,
+    int24 nearestNext
+  ) external {
+    values.insert(newValue, nearestLower, nearestNext);
   }
 
   function remove(int24 value) external {

--- a/test/__snapshots__/Pool.spec.ts.snap
+++ b/test/__snapshots__/Pool.spec.ts.snap
@@ -1,27 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Pool #flash after unlockPool #gas flash [ @skip-on-coverage ] 1`] = `"99957"`;
+exports[`Pool #flash after unlockPool #gas flash [ @skip-on-coverage ] 1`] = `"99948"`;
 
-exports[`Pool #mint after unlockPool successful mints position above current tick #gas [ @skip-on-coverage ] 1`] = `"242417"`;
+exports[`Pool #mint after unlockPool successful mints position above current tick #gas [ @skip-on-coverage ] 1`] = `"242389"`;
 
-exports[`Pool #mint after unlockPool successful mints position above current tick #gas [ @skip-on-coverage ] 2`] = `"165348"`;
+exports[`Pool #mint after unlockPool successful mints position above current tick #gas [ @skip-on-coverage ] 2`] = `"165336"`;
 
-exports[`Pool #mint after unlockPool successful mints position includes current tick #gas [ @skip-on-coverage ] 1`] = `"301608"`;
+exports[`Pool #mint after unlockPool successful mints position includes current tick #gas [ @skip-on-coverage ] 1`] = `"301580"`;
 
-exports[`Pool #mint after unlockPool successful mints position includes current tick #gas [ @skip-on-coverage ] 2`] = `"165579"`;
+exports[`Pool #mint after unlockPool successful mints position includes current tick #gas [ @skip-on-coverage ] 2`] = `"165567"`;
 
-exports[`Pool #unlockPool #gas [ @skip-on-coverage ] 1`] = `"255008"`;
+exports[`Pool #unlockPool #gas [ @skip-on-coverage ] 1`] = `"254996"`;
 
 exports[`Pool burnRTokens init at 0 tick #gas [ @skip-on-coverage ] 1`] = `"81731"`;
 
-exports[`Pool swap init at reasonable tick #gas token0 exactInput - cross 2 initiated ticks [ @skip-on-coverage ] 1`] = `"213661"`;
+exports[`Pool swap init at reasonable tick #gas token0 exactInput - cross 2 initiated ticks [ @skip-on-coverage ] 1`] = `"213659"`;
 
-exports[`Pool swap init at reasonable tick #gas token0 exactInput - cross an initiated tick [ @skip-on-coverage ] 1`] = `"179469"`;
+exports[`Pool swap init at reasonable tick #gas token0 exactInput - cross an initiated tick [ @skip-on-coverage ] 1`] = `"179457"`;
 
-exports[`Pool swap init at reasonable tick #gas token0 exactInput - within a tick [ @skip-on-coverage ] 1`] = `"95571"`;
+exports[`Pool swap init at reasonable tick #gas token0 exactInput - within a tick [ @skip-on-coverage ] 1`] = `"95559"`;
 
-exports[`Pool swap init at reasonable tick #gas token1 exactOutput - cross 2 initiated ticks [ @skip-on-coverage ] 1`] = `"224352"`;
+exports[`Pool swap init at reasonable tick #gas token1 exactOutput - cross 2 initiated ticks [ @skip-on-coverage ] 1`] = `"224350"`;
 
-exports[`Pool swap init at reasonable tick #gas token1 exactOutput - cross an initiated tick [ @skip-on-coverage ] 1`] = `"190397"`;
+exports[`Pool swap init at reasonable tick #gas token1 exactOutput - cross an initiated tick [ @skip-on-coverage ] 1`] = `"190385"`;
 
-exports[`Pool swap init at reasonable tick #gas token1 exactOutput - within a tick [ @skip-on-coverage ] 1`] = `"106518"`;
+exports[`Pool swap init at reasonable tick #gas token1 exactOutput - within a tick [ @skip-on-coverage ] 1`] = `"106506"`;

--- a/test/__snapshots__/Pool.spec.ts.snap
+++ b/test/__snapshots__/Pool.spec.ts.snap
@@ -14,13 +14,13 @@ exports[`Pool #unlockPool #gas [ @skip-on-coverage ] 1`] = `"255008"`;
 
 exports[`Pool burnRTokens init at 0 tick #gas [ @skip-on-coverage ] 1`] = `"81731"`;
 
-exports[`Pool swap init at reasonable tick #gas token0 exactInput - cross 2 initiated ticks [ @skip-on-coverage ] 1`] = `"213671"`;
+exports[`Pool swap init at reasonable tick #gas token0 exactInput - cross 2 initiated ticks [ @skip-on-coverage ] 1`] = `"213661"`;
 
 exports[`Pool swap init at reasonable tick #gas token0 exactInput - cross an initiated tick [ @skip-on-coverage ] 1`] = `"179469"`;
 
 exports[`Pool swap init at reasonable tick #gas token0 exactInput - within a tick [ @skip-on-coverage ] 1`] = `"95571"`;
 
-exports[`Pool swap init at reasonable tick #gas token1 exactOutput - cross 2 initiated ticks [ @skip-on-coverage ] 1`] = `"224362"`;
+exports[`Pool swap init at reasonable tick #gas token1 exactOutput - cross 2 initiated ticks [ @skip-on-coverage ] 1`] = `"224352"`;
 
 exports[`Pool swap init at reasonable tick #gas token1 exactOutput - cross an initiated tick [ @skip-on-coverage ] 1`] = `"190397"`;
 

--- a/test/libraries/Linkedlist.spec.ts
+++ b/test/libraries/Linkedlist.spec.ts
@@ -47,7 +47,7 @@ describe('Linkedlist', () => {
   });
 
   it('revert - insert with uninitialized lower value', async () => {
-    await expect(linkedlist.insert(100, 1, 0)).to.be.revertedWith('lower value is not initialized');  // with an un-initialized lower value, the next value equal to 0
+    await expect(linkedlist.insert(100, 1, 0)).to.be.revertedWith('lower value is not initialized'); // with an un-initialized lower value, the next value equal to 0
   });
 
   it('revert - insert invalid lower value', async () => {
@@ -73,7 +73,7 @@ describe('Linkedlist', () => {
       let t = genRandomSeed(realValues.length - 1);
       let x = realValues[t] + genRandomSeed(realValues[t + 1] - realValues[t]);
       if (x == realValues[t]) continue;
-      await linkedlist.insert(x, realValues[t], realValues[t+1]);
+      await linkedlist.insert(x, realValues[t], realValues[t + 1]);
       realValues.splice(t + 1, 0, x);
       await validateValues();
     }

--- a/test/libraries/Linkedlist.spec.ts
+++ b/test/libraries/Linkedlist.spec.ts
@@ -47,24 +47,33 @@ describe('Linkedlist', () => {
   });
 
   it('revert - insert with uninitialized lower value', async () => {
-    await expect(linkedlist.insert(100, 0)).to.be.revertedWith('lower value is not initialized');
+    await expect(linkedlist.insert(100, 1, 0)).to.be.revertedWith('lower value is not initialized');  // with an un-initialized lower value, the next value equal to 0
   });
 
   it('revert - insert invalid lower value', async () => {
-    await linkedlist.insert(100, MIN_VALUE);
+    await linkedlist.insert(100, MIN_VALUE, MAX_VALUE);
     realValues.splice(1, 0, 100);
-    await expect(linkedlist.insert(1200, MIN_VALUE)).to.be.revertedWith('invalid lower value');
-    await linkedlist.insert(1200, 100);
+    await expect(linkedlist.insert(1200, MIN_VALUE, MAX_VALUE)).to.be.revertedWith('invalid lower value');
+    await linkedlist.insert(1200, 100, MAX_VALUE);
     realValues.splice(2, 0, 1200);
     await validateValues();
   });
 
-  it('correct record insert data', async () => {
+  it('revert - insert invalid next value', async () => {
+    await linkedlist.insert(100, MIN_VALUE, MAX_VALUE);
+    realValues.splice(1, 0, 100);
+    await expect(linkedlist.insert(1200, 100, 1000)).to.be.revertedWith('invalid next value');
+    await linkedlist.insert(1200, 100, MAX_VALUE);
+    realValues.splice(2, 0, 1200);
+    await validateValues();
+  });
+
+  it.only('correct record insert data', async () => {
     for (let i = 0; i < 50; i++) {
       let t = genRandomSeed(realValues.length - 1);
       let x = realValues[t] + genRandomSeed(realValues[t + 1] - realValues[t]);
       if (x == realValues[t]) continue;
-      await linkedlist.insert(x, realValues[t]);
+      await linkedlist.insert(x, realValues[t], realValues[t+1]);
       realValues.splice(t + 1, 0, x);
       await validateValues();
     }

--- a/test/libraries/Linkedlist.spec.ts
+++ b/test/libraries/Linkedlist.spec.ts
@@ -51,24 +51,25 @@ describe('Linkedlist', () => {
   });
 
   it('revert - insert invalid lower value', async () => {
+    // we assume that passed lower value and next value are compatible with each other: lowerValue.next = nextVale
     await linkedlist.insert(100, MIN_VALUE, MAX_VALUE);
     realValues.splice(1, 0, 100);
-    await expect(linkedlist.insert(1200, MIN_VALUE, MAX_VALUE)).to.be.revertedWith('invalid lower value');
+    await expect(linkedlist.insert(1200, MIN_VALUE, 100)).to.be.revertedWith('invalid lower value');
     await linkedlist.insert(1200, 100, MAX_VALUE);
     realValues.splice(2, 0, 1200);
     await validateValues();
   });
 
-  it('revert - insert invalid next value', async () => {
-    await linkedlist.insert(100, MIN_VALUE, MAX_VALUE);
-    realValues.splice(1, 0, 100);
-    await expect(linkedlist.insert(1200, 100, 1000)).to.be.revertedWith('invalid next value');
-    await linkedlist.insert(1200, 100, MAX_VALUE);
-    realValues.splice(2, 0, 1200);
-    await validateValues();
-  });
+  // it('revert - insert invalid next value', async () => {
+  //   await linkedlist.insert(100, MIN_VALUE, MAX_VALUE);
+  //   realValues.splice(1, 0, 100);
+  //   await expect(linkedlist.insert(1200, 100, 1000)).to.be.revertedWith('invalid next value');
+  //   await linkedlist.insert(1200, 100, MAX_VALUE);
+  //   realValues.splice(2, 0, 1200);
+  //   await validateValues();
+  // });
 
-  it.only('correct record insert data', async () => {
+  it('correct record insert data', async () => {
     for (let i = 0; i < 50; i++) {
       let t = genRandomSeed(realValues.length - 1);
       let x = realValues[t] + genRandomSeed(realValues[t + 1] - realValues[t]);

--- a/test/periphery/__snapshots__/Router.spec.ts.snap
+++ b/test/periphery/__snapshots__/Router.spec.ts.snap
@@ -1,21 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Router #swapExactInput #gas 2 pool [ @skip-on-coverage ] 1`] = `"174882"`;
+exports[`Router #swapExactInput #gas 2 pool [ @skip-on-coverage ] 1`] = `"174962"`;
 
-exports[`Router #swapExactInput #gas one pool [ @skip-on-coverage ] 1`] = `"106825"`;
+exports[`Router #swapExactInput #gas one pool [ @skip-on-coverage ] 1`] = `"106816"`;
 
-exports[`Router #swapExactInput #gas one pool [ @skip-on-coverage ] 2`] = `"111451"`;
+exports[`Router #swapExactInput #gas one pool [ @skip-on-coverage ] 2`] = `"111618"`;
 
-exports[`Router #swapExactInput #gas one pool [ @skip-on-coverage ] 3`] = `"111360"`;
+exports[`Router #swapExactInput #gas one pool [ @skip-on-coverage ] 3`] = `"111461"`;
 
-exports[`Router #swapExactInput #gas one pool [ @skip-on-coverage ] 4`] = `"106908"`;
+exports[`Router #swapExactInput #gas one pool [ @skip-on-coverage ] 4`] = `"106899"`;
 
-exports[`Router #swapExactOutput #gas 2 pool [ @skip-on-coverage ] 1`] = `"189838"`;
+exports[`Router #swapExactOutput #gas 2 pool [ @skip-on-coverage ] 1`] = `"189808"`;
 
-exports[`Router #swapExactOutput #gas one pool [ @skip-on-coverage ] 1`] = `"118684"`;
+exports[`Router #swapExactOutput #gas one pool [ @skip-on-coverage ] 1`] = `"118675"`;
 
-exports[`Router #swapExactOutput #gas one pool [ @skip-on-coverage ] 2`] = `"123635"`;
+exports[`Router #swapExactOutput #gas one pool [ @skip-on-coverage ] 2`] = `"123616"`;
 
-exports[`Router #swapExactOutput #gas one pool [ @skip-on-coverage ] 3`] = `"123620"`;
+exports[`Router #swapExactOutput #gas one pool [ @skip-on-coverage ] 3`] = `"123611"`;
 
-exports[`Router #swapExactOutput #gas one pool [ @skip-on-coverage ] 4`] = `"118767"`;
+exports[`Router #swapExactOutput #gas one pool [ @skip-on-coverage ] 4`] = `"118758"`;

--- a/test/periphery/__snapshots__/Router.spec.ts.snap
+++ b/test/periphery/__snapshots__/Router.spec.ts.snap
@@ -1,21 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Router #swapExactInput #gas 2 pool [ @skip-on-coverage ] 1`] = `"174886"`;
+exports[`Router #swapExactInput #gas 2 pool [ @skip-on-coverage ] 1`] = `"174882"`;
 
-exports[`Router #swapExactInput #gas one pool [ @skip-on-coverage ] 1`] = `"111389"`;
+exports[`Router #swapExactInput #gas one pool [ @skip-on-coverage ] 1`] = `"106825"`;
 
-exports[`Router #swapExactInput #gas one pool [ @skip-on-coverage ] 2`] = `"106899"`;
+exports[`Router #swapExactInput #gas one pool [ @skip-on-coverage ] 2`] = `"111451"`;
 
-exports[`Router #swapExactInput #gas one pool [ @skip-on-coverage ] 3`] = `"106888"`;
+exports[`Router #swapExactInput #gas one pool [ @skip-on-coverage ] 3`] = `"111360"`;
 
-exports[`Router #swapExactInput #gas one pool [ @skip-on-coverage ] 4`] = `"111618"`;
+exports[`Router #swapExactInput #gas one pool [ @skip-on-coverage ] 4`] = `"106908"`;
 
-exports[`Router #swapExactOutput #gas 2 pool [ @skip-on-coverage ] 1`] = `"189808"`;
+exports[`Router #swapExactOutput #gas 2 pool [ @skip-on-coverage ] 1`] = `"189838"`;
 
-exports[`Router #swapExactOutput #gas one pool [ @skip-on-coverage ] 1`] = `"123539"`;
+exports[`Router #swapExactOutput #gas one pool [ @skip-on-coverage ] 1`] = `"118684"`;
 
-exports[`Router #swapExactOutput #gas one pool [ @skip-on-coverage ] 2`] = `"118758"`;
+exports[`Router #swapExactOutput #gas one pool [ @skip-on-coverage ] 2`] = `"123635"`;
 
-exports[`Router #swapExactOutput #gas one pool [ @skip-on-coverage ] 3`] = `"118747"`;
+exports[`Router #swapExactOutput #gas one pool [ @skip-on-coverage ] 3`] = `"123620"`;
 
-exports[`Router #swapExactOutput #gas one pool [ @skip-on-coverage ] 4`] = `"123616"`;
+exports[`Router #swapExactOutput #gas one pool [ @skip-on-coverage ] 4`] = `"118767"`;


### PR DESCRIPTION
Passing an additional argument `nextValue` to insert()

Insertions into the linked list through LinkedList:insert() occur only in internal function PoolTicksState:_updateTickList. In insert() the following storage read occurs:
However, that value corresponds to the last nextTick in _updateTickList. Thus, storage reads could be reduced by passing an additional argument to insert.