### PR TITLE
Add supportsInterface() to detect what interfaces a smart contract implements

### DIFF
--- a/contracts/interfaces/periphery/IBasePositionManager.sol
+++ b/contracts/interfaces/periphery/IBasePositionManager.sol
@@ -169,4 +169,14 @@ interface IBasePositionManager is IRouterTokenHelper {
   function nextPoolId() external view returns (uint80);
 
   function nextTokenId() external view returns (uint256);
+
+  /**
+   * @dev Returns true if this contract implements the interface defined by
+   * `interfaceId`. See the corresponding
+   * https://eips.ethereum.org/EIPS/eip-165#how-interfaces-are-identified[EIP section]
+   * to learn more about how these ids are created.
+   *
+   * This function call must use less than 30 000 gas.
+   */
+  function supportsInterface(bytes4 interfaceId) external view returns (bool);
 }

--- a/contracts/interfaces/periphery/IERC721Permit.sol
+++ b/contracts/interfaces/periphery/IERC721Permit.sol
@@ -30,4 +30,14 @@ interface IERC721Permit is IERC721, IERC721Enumerable {
     bytes32 r,
     bytes32 s
   ) external;
+
+  /**
+   * @dev Returns true if this contract implements the interface defined by
+   * `interfaceId`. See the corresponding
+   * https://eips.ethereum.org/EIPS/eip-165#how-interfaces-are-identified[EIP section]
+   * to learn more about how these ids are created.
+   *
+   * This function call must use less than 30 000 gas.
+   */
+  function supportsInterface(bytes4 interfaceId) external view returns (bool);
 }

--- a/contracts/periphery/BasePositionManager.sol
+++ b/contracts/periphery/BasePositionManager.sol
@@ -286,6 +286,22 @@ contract BasePositionManager is
     return _positions[tokenId].operator;
   }
 
+  /**
+   * @dev See {IERC165-supportsInterface}.
+   */
+  function supportsInterface(bytes4 interfaceId)
+    public
+    view
+    virtual
+    override(ERC721Permit, IBasePositionManager)
+    returns (bool)
+  {
+    return
+      interfaceId == type(ERC721Permit).interfaceId ||
+      interfaceId == type(IBasePositionManager).interfaceId ||
+      super.supportsInterface(interfaceId);
+  }
+
   function _storePoolInfo(
     address pool,
     address token0,

--- a/contracts/periphery/base/ERC721Permit.sol
+++ b/contracts/periphery/base/ERC721Permit.sol
@@ -108,4 +108,20 @@ abstract contract ERC721Permit is DeadlineValidation, ERC721Enumerable, IERC721P
       chainId := chainid()
     }
   }
+
+  /**
+   * @dev See {IERC165-supportsInterface}.
+   */
+  function supportsInterface(bytes4 interfaceId)
+    public
+    view
+    virtual
+    override(ERC721Enumerable, IERC721Permit)
+    returns (bool)
+  {
+    return
+      interfaceId == type(ERC721Enumerable).interfaceId ||
+      interfaceId == type(IERC721Permit).interfaceId ||
+      super.supportsInterface(interfaceId);
+  }
 }

--- a/test/periphery/BasePositionManager.spec.ts
+++ b/test/periphery/BasePositionManager.spec.ts
@@ -1557,6 +1557,20 @@ describe('BasePositionManager', () => {
       expect(await positionManager.getApproved(nextTokenId)).to.be.eq(other.address);
     });
   });
+
+  describe(`#supports interface`, async () => {
+    it('support interface', async () => {
+      expect(await positionManager.supportsInterface('0x01ffc9a7')).to.be.eq(true); // ERC165
+      expect(await positionManager.supportsInterface('0x80ac58cd')).to.be.eq(true); // ERC721
+      expect(await positionManager.supportsInterface('0x5b5e139f')).to.be.eq(true); // ERC721Metadata
+      expect(await positionManager.supportsInterface('0x780e9d63')).to.be.eq(true); // ERC721Enumerable
+    });
+
+    it('un-support interface', async () => {
+      expect(await positionManager.supportsInterface('0x8462151c')).to.be.eq(false);
+      expect(await positionManager.supportsInterface('0x80ac583d')).to.be.eq(false);
+    });
+  });
 });
 
 function logMessage(message: string) {

--- a/test/periphery/BasePositionManager.spec.ts
+++ b/test/periphery/BasePositionManager.spec.ts
@@ -1558,12 +1558,14 @@ describe('BasePositionManager', () => {
     });
   });
 
-  describe(`#supports interface`, async () => {
+  describe.only(`#supports interface`, async () => {
     it('support interface', async () => {
       expect(await positionManager.supportsInterface('0x01ffc9a7')).to.be.eq(true); // ERC165
       expect(await positionManager.supportsInterface('0x80ac58cd')).to.be.eq(true); // ERC721
       expect(await positionManager.supportsInterface('0x5b5e139f')).to.be.eq(true); // ERC721Metadata
       expect(await positionManager.supportsInterface('0x780e9d63')).to.be.eq(true); // ERC721Enumerable
+      expect(await positionManager.supportsInterface('0x7dd42bd6')).to.be.eq(true); // ERC721Permit
+      expect(await positionManager.supportsInterface('0xfad9ce15')).to.be.eq(true); // IBasePositionManager
     });
 
     it('un-support interface', async () => {


### PR DESCRIPTION
The ERC-721 specifies that the ERC-165 interface must be implemented which defines a standard
method to publish and detect what interfaces a smart contract implements.

The more derived ERC-721 contracts of Kyber Network do not overwrite this function. Hence, querying the support of the additionally implemented interfaces through supportedInterface() will return false.