### PR TITLE
Anti Snip Attack Fix

### DIFF
--- a/contracts/mock/MockSnipAttack.sol
+++ b/contracts/mock/MockSnipAttack.sol
@@ -1,23 +1,25 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.0;
 
-import '../interfaces/periphery/IBasePositionManager.sol';
 import '../interfaces/IPool.sol';
 import '../libraries/TickMath.sol';
+import '../periphery/AntiSnipAttackPositionManager.sol';
 import {IERC20} from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 
+// import 'hardhat/console.sol';
+
 contract MockSnipAttack {
-  function snip(
-    IBasePositionManager posManager,
+  function snip1(
     IPool pool,
+    AntiSnipAttackPositionManager posManager,
     IBasePositionManager.MintParams calldata params
   ) external {
     IERC20(params.token0).approve(address(posManager), type(uint256).max);
     IERC20(params.token1).approve(address(posManager), type(uint256).max);
     (uint256 tokenId, uint128 liquidity, , ) = posManager.mint(params);
     (IBasePositionManager.Position memory pos, ) = posManager.positions(tokenId);
-    uint256 rTokensOwedBefore = pos.rTokenOwed;
     uint256 feeGrowthInsideLastBefore = pos.feeGrowthInsideLast;
+    // console.log(feeGrowthInsideLastBefore);
 
     // do swap to increase fees
     pool.swap(
@@ -27,6 +29,8 @@ contract MockSnipAttack {
       TickMath.MIN_SQRT_RATIO + 1,
       abi.encode(msg.sender, params.token0, params.token1)
     );
+
+    // remove all liquidity
     posManager.removeLiquidity(
       IBasePositionManager.RemoveLiquidityParams({
         tokenId: tokenId,
@@ -37,11 +41,69 @@ contract MockSnipAttack {
       })
     );
     (pos, ) = posManager.positions(tokenId);
-    // should be different
+    // fee growth should be different
     // using require instead of assert because of coverage error
+    // console.log(pos.feeGrowthInsideLast);
     require(feeGrowthInsideLastBefore != pos.feeGrowthInsideLast, 'same fee growth');
-    // should remain unchanged
-    require(rTokensOwedBefore == pos.rTokenOwed, 'diff rTokens owed');
+    // should owe no rTokens
+    require(pos.rTokenOwed == 0, 'diff rTokens owed');
+  }
+
+  function snip2(
+    AntiSnipAttackPositionManager posManager,
+    IPool pool,
+    IBasePositionManager.MintParams calldata params
+  ) external {
+    IERC20(params.token0).approve(address(posManager), type(uint256).max);
+    IERC20(params.token1).approve(address(posManager), type(uint256).max);
+    (uint256 tokenId, uint128 liquidity, , ) = posManager.mint(params);
+    (IBasePositionManager.Position memory pos, ) = posManager.positions(tokenId);
+    uint256 feeGrowthInsideLastBefore = pos.feeGrowthInsideLast;
+    // console.log(feeGrowthInsideLastBefore);
+
+    // do swap to increase fees
+    pool.swap(
+      address(this),
+      5e19,
+      true,
+      TickMath.MIN_SQRT_RATIO + 1,
+      abi.encode(msg.sender, params.token0, params.token1)
+    );
+
+    // add small liquidity to lock fees
+    (uint128 addedLiquidity, , , ) = posManager.addLiquidity(
+      IBasePositionManager.IncreaseLiquidityParams({
+        tokenId: tokenId,
+        amount0Desired: 1000,
+        amount1Desired: 1000,
+        amount0Min: 0,
+        amount1Min: 0,
+        deadline: block.timestamp
+      })
+    );
+
+    // fee growth should be different
+    // using require instead of assert because of coverage error
+    (pos, ) = posManager.positions(tokenId);
+    // console.log(pos.feeGrowthInsideLast);
+    require(feeGrowthInsideLastBefore != pos.feeGrowthInsideLast, 'same fee growth');
+
+    // remove all liquidity
+    posManager.removeLiquidity(
+      IBasePositionManager.RemoveLiquidityParams({
+        tokenId: tokenId,
+        liquidity: liquidity + addedLiquidity,
+        amount0Min: 0,
+        amount1Min: 0,
+        deadline: block.timestamp
+      })
+    );
+    (pos, ) = posManager.positions(tokenId);
+    // should owe no rTokens
+    require(pos.rTokenOwed == 0, 'diff rTokens owed');
+    // should have zero fees locked (burnt all)
+    (, , , uint256 feesLocked) = posManager.antiSnipAttackData(tokenId);
+    require(feesLocked == 0, 'non-zero fees locked');
   }
 
   function swapCallback(

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "decimal.js": "^10.3.1",
     "ethereum-waffle": "3.3.0",
     "ethers": "5.0.0",
-    "hardhat": "2.6.0",
+    "hardhat": "2.8.0-dev.0",
     "hardhat-contract-sizer": "^2.0.3",
     "hardhat-gas-reporter": "1.0.4",
     "hardhat-typechain": "0.3.5",

--- a/test/__snapshots__/Pool.spec.ts.snap
+++ b/test/__snapshots__/Pool.spec.ts.snap
@@ -8,7 +8,7 @@ exports[`Pool #mint after unlockPool successful mints position above current tic
 
 exports[`Pool #mint after unlockPool successful mints position includes current tick #gas [ @skip-on-coverage ] 1`] = `"301592"`;
 
-exports[`Pool #mint after unlockPool successful mints position includes current tick #gas [ @skip-on-coverage ] 2`] = `"165577"`;
+exports[`Pool #mint after unlockPool successful mints position includes current tick #gas [ @skip-on-coverage ] 2`] = `"165579"`;
 
 exports[`Pool #unlockPool #gas [ @skip-on-coverage ] 1`] = `"255008"`;
 

--- a/test/periphery/__snapshots__/Router.spec.ts.snap
+++ b/test/periphery/__snapshots__/Router.spec.ts.snap
@@ -1,20 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Router #swapExactInput #gas 2 pool [ @skip-on-coverage ] 1`] = `"174818"`;
+exports[`Router #swapExactInput #gas 2 pool [ @skip-on-coverage ] 1`] = `"179345"`;
 
-exports[`Router #swapExactInput #gas one pool [ @skip-on-coverage ] 1`] = `"111300"`;
+exports[`Router #swapExactInput #gas one pool [ @skip-on-coverage ] 1`] = `"106825"`;
 
-exports[`Router #swapExactInput #gas one pool [ @skip-on-coverage ] 2`] = `"106920"`;
+exports[`Router #swapExactInput #gas one pool [ @skip-on-coverage ] 2`] = `"111451"`;
 
 exports[`Router #swapExactInput #gas one pool [ @skip-on-coverage ] 3`] = `"106909"`;
 
 exports[`Router #swapExactInput #gas one pool [ @skip-on-coverage ] 4`] = `"111463"`;
 
-exports[`Router #swapExactOutput #gas 2 pool [ @skip-on-coverage ] 1`] = `"189850"`;
+exports[`Router #swapExactOutput #gas 2 pool [ @skip-on-coverage ] 1`] = `"194702"`;
 
-exports[`Router #swapExactOutput #gas one pool [ @skip-on-coverage ] 1`] = `"123560"`;
+exports[`Router #swapExactOutput #gas one pool [ @skip-on-coverage ] 1`] = `"118684"`;
 
-exports[`Router #swapExactOutput #gas one pool [ @skip-on-coverage ] 2`] = `"118779"`;
+exports[`Router #swapExactOutput #gas one pool [ @skip-on-coverage ] 2`] = `"123635"`;
 
 exports[`Router #swapExactOutput #gas one pool [ @skip-on-coverage ] 3`] = `"118768"`;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1082,11 +1082,6 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@solidity-parser/parser@^0.11.0":
-  version "0.11.1"
-  resolved "https://registry.yarnpkg.com/@solidity-parser/parser/-/parser-0.11.1.tgz#fa840af64840c930f24a9c82c08d4a092a068add"
-  integrity sha512-H8BSBoKE8EubJa0ONqecA2TviT3TnHeC4NpgnAHSUiuhZoQBfPB4L2P9bs8R6AoTW10Endvh3vc+fomVMIDIYQ==
-
 "@solidity-parser/parser@^0.12.0":
   version "0.12.2"
   resolved "https://registry.yarnpkg.com/@solidity-parser/parser/-/parser-0.12.2.tgz#1afad367cb29a2ed8cdd4a3a62701c2821fb578f"
@@ -1096,6 +1091,13 @@
   version "0.13.2"
   resolved "https://registry.yarnpkg.com/@solidity-parser/parser/-/parser-0.13.2.tgz#b6c71d8ca0b382d90a7bbed241f9bc110af65cbe"
   integrity sha512-RwHnpRnfrnD2MSPveYoPh8nhofEvX7fgjHk1Oq+NNvCcLx4r1js91CO9o+F/F3fBzOCyvm8kKRTriFICX/odWw==
+  dependencies:
+    antlr4ts "^0.5.0-alpha.4"
+
+"@solidity-parser/parser@^0.14.0":
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/@solidity-parser/parser/-/parser-0.14.0.tgz#d51f074efb0acce0e953ec48133561ed710cebc0"
+  integrity sha512-cX0JJRcmPtNUJpzD2K7FdA7qQsTOk1UZnFx2k7qAg9ZRvuaH5NBe5IEdBMXGlmf2+FmjhqbygJ26H8l2SV7aKQ==
   dependencies:
     antlr4ts "^0.5.0-alpha.4"
 
@@ -5434,10 +5436,10 @@ hardhat-typechain@0.3.5:
   resolved "https://registry.yarnpkg.com/hardhat-typechain/-/hardhat-typechain-0.3.5.tgz#8e50616a9da348b33bd001168c8fda9c66b7b4af"
   integrity sha512-w9lm8sxqTJACY+V7vijiH+NkPExnmtiQEjsV9JKD1KgMdVk2q8y+RhvU/c4B7+7b1+HylRUCxpOIvFuB3rE4+w==
 
-hardhat@2.6.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/hardhat/-/hardhat-2.6.0.tgz#a00a44d36559a880c170dca6363cc33f7545364b"
-  integrity sha512-NEM2pe11QXWXB7k49heOLQA9vxihG4DJ0712KjMT9NYSZgLOMcWswJ3tvn+/ND6vzLn6Z4pqr2x/kWSfllWFuw==
+hardhat@2.8.0-dev.0:
+  version "2.8.0-dev.0"
+  resolved "https://registry.yarnpkg.com/hardhat/-/hardhat-2.8.0-dev.0.tgz#6bc4ee7dd59b8aed18394680c321b8709b5bd638"
+  integrity sha512-s0xOYxmxwui789VO2eCfGrj+hh4GDJT32Eqa/kpxfqp1i7ODBONU1iJv/E7aPfLojxsKiHab//bo5hT8gUkb+g==
   dependencies:
     "@ethereumjs/block" "^3.4.0"
     "@ethereumjs/blockchain" "^5.4.0"
@@ -5446,7 +5448,7 @@ hardhat@2.6.0:
     "@ethereumjs/vm" "^5.5.2"
     "@ethersproject/abi" "^5.1.2"
     "@sentry/node" "^5.18.1"
-    "@solidity-parser/parser" "^0.11.0"
+    "@solidity-parser/parser" "^0.14.0"
     "@types/bn.js" "^5.1.0"
     "@types/lru-cache" "^5.1.0"
     abort-controller "^3.0.0"
@@ -5484,7 +5486,7 @@ hardhat@2.6.0:
     stacktrace-parser "^0.1.10"
     "true-case-path" "^2.2.1"
     tsort "0.0.1"
-    uuid "^3.3.2"
+    uuid "^8.3.2"
     ws "^7.4.6"
 
 has-ansi@^2.0.0:
@@ -10128,6 +10130,11 @@ uuid@^3.3.2:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
+
+uuid@^8.3.2:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
 validate-npm-package-license@^3.0.1:
   version "3.0.4"


### PR DESCRIPTION
- Remove modifier for overriding `mint()` method because it calls parent method which already contains it
- Use suggested optimization for retrieval of liquidity and feeGrowthInsideLast values
- Fixed bypassing of anti-snipping mechanism via add-add-remove pattern by updating regardless of fee growth difference